### PR TITLE
Project audit: fix preferences data loss, GTK 4.6 baseline crashes, scanner parsing, and UX gaps

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -43,7 +43,10 @@ jobs:
         run: uv lock
 
       - name: Export dependencies for audit
-        run: uv export --all-groups --format requirements.txt \
+        # Must be a block scalar: a plain scalar folds the newlines and turns
+        # the backslash continuations into literal arguments, breaking uv.
+        run: |
+          uv export --all-groups --format requirements.txt \
             --no-hashes --no-emit-local \
             -o requirements-audit.txt
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,7 @@ src/app.py
 src/main.py
 src/cli/help_cmd.py
 src/cli/history_cmd.py
+src/cli/install_helper.py
 src/cli/profile_cmd.py
 src/cli/quarantine_cmd.py
 src/cli/router.py
@@ -12,13 +13,13 @@ src/cli/scan_cmd.py
 src/cli/scheduled_scan.py
 src/cli/status_cmd.py
 src/notification_dispatcher.py
+src/core/clamav_config.py
 src/core/clamav_detection.py
 src/core/system_audit.py
 src/core/file_manager_integration.py
 src/core/keyring_manager.py
 src/core/device_monitor.py
 src/core/notification_manager.py
-src/core/portmaster_client.py
 src/core/quarantine/manager.py
 src/core/result_formatters.py
 src/core/scanner_base.py

--- a/po/clamui.pot
+++ b/po/clamui.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ClamUI 0.2.0\n"
+"Project-Id-Version: ClamUI 0.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linx-systems/clamui/issues\n"
-"POT-Creation-Date: 2026-06-09 19:59+0200\n"
+"POT-Creation-Date: 2026-07-01 20:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr[1] ""
 msgid "Select File or Folder"
 msgstr ""
 
-#: src/cli/help_cmd.py:23 src/cli/scan_cmd.py:33
+#: src/cli/help_cmd.py:23 src/cli/scan_cmd.py:34
 msgid "Scan files or directories for threats"
 msgstr ""
 
@@ -54,83 +54,87 @@ msgid "View scan history"
 msgstr ""
 
 #: src/cli/help_cmd.py:65
+msgid "Install the polkit helper for saving system ClamAV configs"
+msgstr ""
+
+#: src/cli/help_cmd.py:71
 msgid "Show this help message"
 msgstr ""
 
-#: src/cli/help_cmd.py:78
+#: src/cli/help_cmd.py:84
 msgid "Show detailed help and usage examples"
 msgstr ""
 
-#: src/cli/help_cmd.py:79
+#: src/cli/help_cmd.py:85
 msgid ""
 "Display an overview of all commands or detailed help for a specific one."
 msgstr ""
 
-#: src/cli/help_cmd.py:85
+#: src/cli/help_cmd.py:91
 msgid "Command to show help for"
 msgstr ""
 
-#: src/cli/help_cmd.py:92
+#: src/cli/help_cmd.py:98
 msgid "ClamUI — ClamAV antivirus management\n"
 msgstr ""
 
-#: src/cli/help_cmd.py:93
+#: src/cli/help_cmd.py:99
 msgid "Usage:"
 msgstr ""
 
-#: src/cli/help_cmd.py:94
+#: src/cli/help_cmd.py:100
 msgid "  clamui                   Launch the graphical interface"
 msgstr ""
 
-#: src/cli/help_cmd.py:95
+#: src/cli/help_cmd.py:101
 msgid "  clamui <command> [args]   Run a CLI command\n"
 msgstr ""
 
-#: src/cli/help_cmd.py:96
+#: src/cli/help_cmd.py:102
 msgid "Commands:"
 msgstr ""
 
-#: src/cli/help_cmd.py:104
+#: src/cli/help_cmd.py:110
 msgid ""
 "\n"
 "Global options:"
 msgstr ""
 
-#: src/cli/help_cmd.py:105
+#: src/cli/help_cmd.py:111
 msgid "  --json                   Machine-readable JSON output"
 msgstr ""
 
-#: src/cli/help_cmd.py:106
+#: src/cli/help_cmd.py:112
 msgid "  -v, --verbose            Verbose output"
 msgstr ""
 
-#: src/cli/help_cmd.py:107
+#: src/cli/help_cmd.py:113
 msgid "  -h, --help               Show help for any command\n"
 msgstr ""
 
-#: src/cli/help_cmd.py:108
+#: src/cli/help_cmd.py:114
 msgid "Run 'clamui help <command>' for usage examples."
 msgstr ""
 
-#: src/cli/help_cmd.py:109
+#: src/cli/help_cmd.py:115
 msgid "Run 'clamui' without arguments to launch the GUI."
 msgstr ""
 
-#: src/cli/help_cmd.py:125
+#: src/cli/help_cmd.py:131
 #, python-brace-format
 msgid "Unknown command: {name}\n"
 msgstr ""
 
-#: src/cli/help_cmd.py:132
+#: src/cli/help_cmd.py:138
 #, python-brace-format
 msgid "clamui {name} — {summary}\n"
 msgstr ""
 
-#: src/cli/help_cmd.py:133
+#: src/cli/help_cmd.py:139
 msgid "Examples:"
 msgstr ""
 
-#: src/cli/help_cmd.py:136
+#: src/cli/help_cmd.py:142
 #, python-brace-format
 msgid ""
 "\n"
@@ -192,6 +196,51 @@ msgid ""
 "Showing {shown} of {total} entries. Use --limit to see more."
 msgstr ""
 
+#: src/cli/install_helper.py:88
+#, python-brace-format
+msgid "Required source file not found: {path}"
+msgstr ""
+
+#: src/cli/install_helper.py:98
+msgid "Unexpected relative import remains in the helper source; aborting."
+msgstr ""
+
+#: src/cli/install_helper.py:126
+#, python-brace-format
+msgid "Failed to install privileged helper: {error}"
+msgstr ""
+
+#: src/cli/install_helper.py:131
+#, python-brace-format
+msgid ""
+"Installed privileged helper at {bin} and polkit policy at {policy}. Saving "
+"system ClamAV configuration from ClamUI should now work."
+msgstr ""
+
+#: src/cli/install_helper.py:145
+msgid ""
+"This command installs files under /usr and /usr/share and must be run as "
+"root. Try: sudo clamui install-privileged-helper"
+msgstr ""
+
+#: src/cli/install_helper.py:157 src/core/result_formatters.py:124
+#: src/ui/update_view.py:682
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: src/cli/install_helper.py:165
+msgid "Install the privileged config helper and polkit policy (run with sudo)"
+msgstr ""
+
+#: src/cli/install_helper.py:167
+msgid ""
+"Install /usr/bin/clamui-apply-preferences and its polkit policy so ClamUI "
+"can save system ClamAV configuration. Run as root (sudo). Needed for "
+"AppImage, Flatpak, and pip installs; the Debian package installs these "
+"automatically."
+msgstr ""
+
 #: src/cli/profile_cmd.py:28
 msgid "List, view, export, or import scan profiles."
 msgstr ""
@@ -228,7 +277,7 @@ msgstr ""
 msgid "No scan profiles configured."
 msgstr ""
 
-#: src/cli/profile_cmd.py:88 src/ui/profile_dialogs.py:167
+#: src/cli/profile_cmd.py:88 src/ui/profile_dialogs.py:169
 msgid "Name"
 msgstr ""
 
@@ -269,7 +318,7 @@ msgid ""
 msgstr ""
 
 #: src/cli/profile_cmd.py:122 src/cli/profile_cmd.py:176
-#: src/cli/scan_cmd.py:113
+#: src/cli/scan_cmd.py:114
 #, python-brace-format
 msgid "Profile not found: {name}"
 msgstr ""
@@ -374,7 +423,7 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: src/cli/quarantine_cmd.py:78 src/ui/virustotal_results_dialog.py:236
+#: src/cli/quarantine_cmd.py:78 src/ui/virustotal_results_dialog.py:237
 msgid "File"
 msgstr ""
 
@@ -434,97 +483,97 @@ msgstr ""
 msgid "commands"
 msgstr ""
 
-#: src/cli/scan_cmd.py:35
+#: src/cli/scan_cmd.py:36
 msgid ""
 "Scan one or more files or directories with ClamAV.\n"
 "Exit codes: 0 = clean, 1 = threats found, 2 = error."
 msgstr ""
 
-#: src/cli/scan_cmd.py:44
+#: src/cli/scan_cmd.py:45
 msgid "Files or directories to scan"
 msgstr ""
 
-#: src/cli/scan_cmd.py:50
+#: src/cli/scan_cmd.py:51
 msgid "Do not scan directories recursively"
 msgstr ""
 
-#: src/cli/scan_cmd.py:56
+#: src/cli/scan_cmd.py:57
 msgid "Use a named scan profile for exclusions"
 msgstr ""
 
-#: src/cli/scan_cmd.py:62 src/cli/scheduled_scan.py:127
+#: src/cli/scan_cmd.py:63 src/cli/scheduled_scan.py:127
 #: src/ui/preferences/scheduled_page.py:182
 msgid "Automatically quarantine detected threats"
 msgstr ""
 
-#: src/cli/scan_cmd.py:68
+#: src/cli/scan_cmd.py:69
 msgid "Output results as JSON"
 msgstr ""
 
-#: src/cli/scan_cmd.py:74 src/cli/scheduled_scan.py:144
+#: src/cli/scan_cmd.py:75 src/cli/scheduled_scan.py:144
 msgid "Enable verbose output"
 msgstr ""
 
-#: src/cli/scan_cmd.py:95
+#: src/cli/scan_cmd.py:96
 #, python-brace-format
 msgid "Path not found: {path}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:116
+#: src/cli/scan_cmd.py:117
 #, python-brace-format
 msgid "Using profile: {name}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:144
+#: src/cli/scan_cmd.py:145
 #, python-brace-format
 msgid "Scanning: {path}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:227
+#: src/cli/scan_cmd.py:228
 #, python-brace-format
 msgid "Scanned {count} files in {duration:.1f}s"
 msgstr ""
 
-#: src/cli/scan_cmd.py:231
+#: src/cli/scan_cmd.py:232
 #, python-brace-format
 msgid ""
 "\n"
 "Threats found: {count}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:238
+#: src/cli/scan_cmd.py:239
 #, python-brace-format
 msgid ""
 "\n"
 "Quarantined: {count} file(s)"
 msgstr ""
 
-#: src/cli/scan_cmd.py:240
+#: src/cli/scan_cmd.py:241
 msgid ""
 "\n"
 "Failed to quarantine:"
 msgstr ""
 
-#: src/cli/scan_cmd.py:244
+#: src/cli/scan_cmd.py:245
 msgid ""
 "\n"
 "Scan completed with errors:"
 msgstr ""
 
-#: src/cli/scan_cmd.py:249
+#: src/cli/scan_cmd.py:250
 msgid "No threats found."
 msgstr ""
 
-#: src/cli/scan_cmd.py:265
+#: src/cli/scan_cmd.py:266
 msgid "No valid paths to scan"
 msgstr ""
 
-#: src/cli/scan_cmd.py:273
+#: src/cli/scan_cmd.py:275
 #, python-brace-format
 msgid "ClamAV not available: {error}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:276 src/cli/scheduled_scan.py:323
+#: src/cli/scan_cmd.py:278 src/cli/scheduled_scan.py:323
 #, python-brace-format
 msgid "ClamAV version: {version}"
 msgstr ""
@@ -776,51 +825,51 @@ msgstr ""
 msgid "Display ClamAV availability, backend, daemon, and statistics."
 msgstr ""
 
-#: src/cli/status_cmd.py:121
+#: src/cli/status_cmd.py:124
 msgid "ClamAV"
-msgstr ""
-
-#: src/cli/status_cmd.py:123
-#, python-brace-format
-msgid "  Version:  {version}"
-msgstr ""
-
-#: src/cli/status_cmd.py:125
-msgid "  Status:   not available"
 msgstr ""
 
 #: src/cli/status_cmd.py:126
 #, python-brace-format
+msgid "  Version:  {version}"
+msgstr ""
+
+#: src/cli/status_cmd.py:128
+msgid "  Status:   not available"
+msgstr ""
+
+#: src/cli/status_cmd.py:129
+#, python-brace-format
 msgid "  Error:    {error}"
 msgstr ""
 
-#: src/cli/status_cmd.py:127
+#: src/cli/status_cmd.py:130
 #, python-brace-format
 msgid "  Backend:  {backend}"
 msgstr ""
 
-#: src/cli/status_cmd.py:128
+#: src/cli/status_cmd.py:131
 #, python-brace-format
 msgid "  Daemon:   {status}"
 msgstr ""
 
-#: src/cli/status_cmd.py:130
+#: src/cli/status_cmd.py:133
 msgid ""
 "\n"
 "Quarantine"
 msgstr ""
 
-#: src/cli/status_cmd.py:131 src/cli/status_cmd.py:135
+#: src/cli/status_cmd.py:134 src/cli/status_cmd.py:138
 #, python-brace-format
 msgid "  Entries:  {count}"
 msgstr ""
 
-#: src/cli/status_cmd.py:132
+#: src/cli/status_cmd.py:135
 #, python-brace-format
 msgid "  Size:     {size}"
 msgstr ""
 
-#: src/cli/status_cmd.py:134
+#: src/cli/status_cmd.py:137
 msgid ""
 "\n"
 "Scan History"
@@ -846,7 +895,7 @@ msgid "Scanned {count} files. System appears clean."
 msgstr ""
 
 #: src/notification_dispatcher.py:41 src/core/result_formatters.py:128
-#: src/ui/scan_results_dialog.py:207
+#: src/ui/scan_results_dialog.py:208
 msgid "Scan Cancelled"
 msgstr ""
 
@@ -855,7 +904,7 @@ msgid "The scan was cancelled by the user."
 msgstr ""
 
 #: src/notification_dispatcher.py:44 src/core/result_formatters.py:120
-#: src/ui/scan_results_dialog.py:222 src/ui/virustotal_results_dialog.py:196
+#: src/ui/scan_results_dialog.py:223 src/ui/virustotal_results_dialog.py:197
 msgid "Scan Error"
 msgstr ""
 
@@ -901,771 +950,809 @@ msgstr ""
 msgid "No threats detected by VirusTotal"
 msgstr ""
 
-#: src/core/clamav_detection.py:47
+#: src/core/clamav_config.py:1051
+msgid ""
+"ClamUI privileged helper not installed. Install the 'clamui' package on your "
+"host system to apply settings."
+msgstr ""
+
+#: src/core/clamav_config.py:1095
+msgid ""
+"The staging directory is not reachable by the privileged helper running on "
+"the host, so preferences cannot be applied from the Flatpak sandbox. A host-"
+"side ClamUI install is required to change system configuration."
+msgstr ""
+
+#: src/core/clamav_config.py:1109
+msgid "Authentication was canceled. Configuration changes were not applied."
+msgstr ""
+
+#: src/core/clamav_config.py:1115
+msgid ""
+"Could not obtain administrator authorization to apply these changes. If you "
+"were not shown a password prompt, the ClamUI polkit policy or privileged "
+"helper is likely not installed on this system -- install the ClamUI system "
+"package (which provides clamui-apply-preferences and its polkit policy) to "
+"enable saving system configuration."
+msgstr ""
+
+#: src/core/clamav_config.py:1127
+msgid ""
+"Privileged helper rejected the request: missing PKEXEC_UID. The polkit "
+"policy may be misconfigured."
+msgstr ""
+
+#: src/core/clamav_config.py:1135
+msgid ""
+"Privileged helper rejected the request: protocol mismatch. Update the "
+"'clamui' package on the host."
+msgstr ""
+
+#: src/core/clamav_detection.py:76
 msgid ""
 "ClamAV is not installed. Please install it with: sudo apt install clamav"
 msgstr ""
 
-#: src/core/clamav_detection.py:66
+#: src/core/clamav_detection.py:95
 #, python-brace-format
 msgid "ClamAV found but returned error: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:70
+#: src/core/clamav_detection.py:99
 msgid "ClamAV check timed out"
 msgstr ""
 
-#: src/core/clamav_detection.py:72
+#: src/core/clamav_detection.py:101
 msgid "ClamAV executable not found"
 msgstr ""
 
-#: src/core/clamav_detection.py:74
+#: src/core/clamav_detection.py:103
 msgid "Permission denied when accessing ClamAV"
 msgstr ""
 
-#: src/core/clamav_detection.py:76
+#: src/core/clamav_detection.py:105
 #, python-brace-format
 msgid "Error checking ClamAV: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:95
+#: src/core/clamav_detection.py:124
 msgid ""
 "freshclam is not installed. Please install it with: sudo apt install clamav-"
 "freshclam"
 msgstr ""
 
-#: src/core/clamav_detection.py:117
+#: src/core/clamav_detection.py:146
 #, python-brace-format
 msgid "freshclam found but returned error: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:123
+#: src/core/clamav_detection.py:152
 msgid "freshclam check timed out"
 msgstr ""
 
-#: src/core/clamav_detection.py:125 src/core/updater.py:555
+#: src/core/clamav_detection.py:154 src/core/updater.py:562
 msgid "freshclam executable not found"
 msgstr ""
 
-#: src/core/clamav_detection.py:127
+#: src/core/clamav_detection.py:156
 msgid "Permission denied when accessing freshclam"
 msgstr ""
 
-#: src/core/clamav_detection.py:129
+#: src/core/clamav_detection.py:158
 #, python-brace-format
 msgid "Error checking freshclam: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:147 src/core/clamav_detection.py:176
+#: src/core/clamav_detection.py:176 src/core/clamav_detection.py:205
 msgid ""
 "clamdscan is not installed. Please install it with: sudo apt install clamav-"
 "daemon"
 msgstr ""
 
-#: src/core/clamav_detection.py:168
+#: src/core/clamav_detection.py:197
 #, python-brace-format
 msgid "clamdscan returned error: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:172
+#: src/core/clamav_detection.py:201
 msgid "clamdscan check timed out"
 msgstr ""
 
-#: src/core/clamav_detection.py:179
+#: src/core/clamav_detection.py:208
 msgid "Permission denied when accessing clamdscan"
 msgstr ""
 
-#: src/core/clamav_detection.py:181
+#: src/core/clamav_detection.py:210
 #, python-brace-format
 msgid "Error checking clamdscan: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:269
+#: src/core/clamav_detection.py:298
 msgid "Could not find clamd socket. Is clamav-daemon installed?"
 msgstr ""
 
-#: src/core/clamav_detection.py:301
+#: src/core/clamav_detection.py:330
 #, python-brace-format
 msgid ""
 "Daemon socket permission denied. Check LocalSocketMode or LocalSocketGroup "
 "in {path}: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:306
+#: src/core/clamav_detection.py:335
 #, python-brace-format
 msgid "Daemon socket permission denied: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:308
+#: src/core/clamav_detection.py:337
 #, python-brace-format
 msgid "Daemon not responding: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:311
+#: src/core/clamav_detection.py:340
 msgid "Connection to clamd timed out"
 msgstr ""
 
-#: src/core/clamav_detection.py:313
+#: src/core/clamav_detection.py:342
 msgid "clamdscan executable not found"
 msgstr ""
 
-#: src/core/clamav_detection.py:315
+#: src/core/clamav_detection.py:344
 #, python-brace-format
 msgid "Error connecting to clamd: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:341
+#: src/core/clamav_detection.py:370
 #, python-brace-format
 msgid "Database directory does not exist: {path}"
 msgstr ""
 
-#: src/core/clamav_detection.py:348
+#: src/core/clamav_detection.py:377
 #, python-brace-format
 msgid "Permission denied accessing: {path}"
 msgstr ""
 
-#: src/core/clamav_detection.py:350
+#: src/core/clamav_detection.py:379
 #, python-brace-format
 msgid "Error accessing database: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:352
+#: src/core/clamav_detection.py:381
 msgid "No virus database files found. Please download the database first."
 msgstr ""
 
-#: src/core/clamav_detection.py:386
+#: src/core/clamav_detection.py:415
 #, python-brace-format
 msgid "Timed out checking host database directory: {path}"
 msgstr ""
 
-#: src/core/clamav_detection.py:388 src/core/system_audit.py:264
+#: src/core/clamav_detection.py:417 src/core/system_audit.py:265
 msgid "flatpak-spawn not available"
 msgstr ""
 
-#: src/core/clamav_detection.py:390
+#: src/core/clamav_detection.py:419
 #, python-brace-format
 msgid "Error checking host database directory: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:396
+#: src/core/clamav_detection.py:425
 #, python-brace-format
 msgid "Error accessing host database directory {path}: {error}"
 msgstr ""
 
-#: src/core/clamav_detection.py:404
+#: src/core/clamav_detection.py:433
 #, python-brace-format
 msgid "No virus database files found in host directory: {path}"
 msgstr ""
 
-#: src/core/clamav_detection.py:460
+#: src/core/clamav_detection.py:489
 msgid "No host database directories were found"
 msgstr ""
 
-#: src/core/clamav_detection.py:464
+#: src/core/clamav_detection.py:493
 #, python-brace-format
 msgid ""
 "No host ClamAV virus database files found. Update the host database with "
 "freshclam. Details: {detail}"
 msgstr ""
 
-#: src/core/system_audit.py:262
+#: src/core/system_audit.py:263
 msgid "Timed out reading database"
 msgstr ""
 
-#: src/core/system_audit.py:268 src/core/system_audit.py:277
+#: src/core/system_audit.py:269 src/core/system_audit.py:278
 msgid "Permission denied reading database"
 msgstr ""
 
-#: src/core/system_audit.py:275
+#: src/core/system_audit.py:276
 msgid "Database file not found"
 msgstr ""
 
-#: src/core/system_audit.py:297
+#: src/core/system_audit.py:298
 msgid "Invalid database file format"
 msgstr ""
 
-#: src/core/system_audit.py:307
+#: src/core/system_audit.py:314
 msgid "Could not parse database timestamp"
 msgstr ""
 
-#: src/core/system_audit.py:427 src/ui/audit_view.py:194
+#: src/core/system_audit.py:434 src/ui/audit_view.py:194
 msgid "ClamAV Health"
 msgstr ""
 
-#: src/core/system_audit.py:436 src/core/system_audit.py:445
+#: src/core/system_audit.py:443 src/core/system_audit.py:452
 msgid "ClamAV Installation"
 msgstr ""
 
-#: src/core/system_audit.py:438
+#: src/core/system_audit.py:445
 #, python-brace-format
 msgid "Installed: {version}"
 msgstr ""
 
-#: src/core/system_audit.py:447
+#: src/core/system_audit.py:454
 msgid "ClamAV is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:448
+#: src/core/system_audit.py:455
 msgid "Install ClamAV to enable virus scanning"
 msgstr ""
 
-#: src/core/system_audit.py:464 src/core/system_audit.py:475
-#: src/core/system_audit.py:488 src/core/system_audit.py:503
-#: src/core/system_audit.py:516 src/core/system_audit.py:527
+#: src/core/system_audit.py:471 src/core/system_audit.py:482
+#: src/core/system_audit.py:495 src/core/system_audit.py:510
+#: src/core/system_audit.py:523 src/core/system_audit.py:534
 msgid "Virus Database"
 msgstr ""
 
-#: src/core/system_audit.py:466
+#: src/core/system_audit.py:473
 #, python-brace-format
 msgid "Up to date ({days} days old, built {date})"
 msgstr ""
 
-#: src/core/system_audit.py:477 src/core/system_audit.py:490
+#: src/core/system_audit.py:484 src/core/system_audit.py:497
 #, python-brace-format
 msgid "Database is {days} days old (built {date})"
 msgstr ""
 
-#: src/core/system_audit.py:480
+#: src/core/system_audit.py:487
 msgid "Update virus database to ensure protection"
 msgstr ""
 
-#: src/core/system_audit.py:493
+#: src/core/system_audit.py:500
 msgid "Database is critically outdated. Update immediately."
 msgstr ""
 
-#: src/core/system_audit.py:505
+#: src/core/system_audit.py:512
 #, python-brace-format
 msgid "Database built {date} (age could not be determined)"
 msgstr ""
 
-#: src/core/system_audit.py:518
+#: src/core/system_audit.py:525
 msgid "No virus database found"
 msgstr ""
 
-#: src/core/system_audit.py:519
+#: src/core/system_audit.py:526
 msgid "Download virus database"
 msgstr ""
 
-#: src/core/system_audit.py:529
+#: src/core/system_audit.py:536
 msgid "Database files exist but age could not be determined"
 msgstr ""
 
-#: src/core/system_audit.py:540 src/core/system_audit.py:553
-#: src/core/system_audit.py:562 src/ui/logs_view.py:266
+#: src/core/system_audit.py:547 src/core/system_audit.py:560
+#: src/core/system_audit.py:569 src/ui/logs_view.py:278
 msgid "ClamAV Daemon"
 msgstr ""
 
-#: src/core/system_audit.py:542
+#: src/core/system_audit.py:549
 #, python-brace-format
 msgid "Service {name} is running"
 msgstr ""
 
-#: src/core/system_audit.py:555
+#: src/core/system_audit.py:562
 msgid "Daemon is responding"
 msgstr ""
 
-#: src/core/system_audit.py:564
+#: src/core/system_audit.py:571
 msgid "ClamAV daemon is not running"
 msgstr ""
 
-#: src/core/system_audit.py:565
+#: src/core/system_audit.py:572
 msgid "Start the daemon for faster scanning"
 msgstr ""
 
-#: src/core/system_audit.py:577 src/core/system_audit.py:587
-#: src/core/system_audit.py:950 src/core/system_audit.py:1020
+#: src/core/system_audit.py:584 src/core/system_audit.py:594
+#: src/core/system_audit.py:957 src/core/system_audit.py:1027
 #: src/ui/audit_view.py:203
 msgid "Automatic Updates"
 msgstr ""
 
-#: src/core/system_audit.py:579
+#: src/core/system_audit.py:586
 msgid "Freshclam service is active"
 msgstr ""
 
-#: src/core/system_audit.py:589
+#: src/core/system_audit.py:596
 msgid "Freshclam automatic update service is not running"
 msgstr ""
 
-#: src/core/system_audit.py:590
+#: src/core/system_audit.py:597
 msgid "Enable automatic database updates"
 msgstr ""
 
-#: src/core/system_audit.py:603 src/core/system_audit.py:681
+#: src/core/system_audit.py:610 src/core/system_audit.py:688
 #: src/ui/audit_view.py:195
 msgid "Firewall"
 msgstr ""
 
-#: src/core/system_audit.py:618 src/core/system_audit.py:628
+#: src/core/system_audit.py:625 src/core/system_audit.py:635
 msgid "UFW Firewall"
 msgstr ""
 
-#: src/core/system_audit.py:620
+#: src/core/system_audit.py:627
 msgid "UFW is active and enabled"
 msgstr ""
 
-#: src/core/system_audit.py:630
+#: src/core/system_audit.py:637
 msgid "UFW service is running but firewall may be disabled"
 msgstr ""
 
-#: src/core/system_audit.py:631
+#: src/core/system_audit.py:638
 msgid "Enable the firewall"
 msgstr ""
 
-#: src/core/system_audit.py:644 src/core/system_audit.py:654
+#: src/core/system_audit.py:651 src/core/system_audit.py:661
 msgid "Firewalld"
 msgstr ""
 
-#: src/core/system_audit.py:646
+#: src/core/system_audit.py:653
 msgid "Firewalld is running"
 msgstr ""
 
-#: src/core/system_audit.py:656
+#: src/core/system_audit.py:663
 msgid "Firewalld is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:657
+#: src/core/system_audit.py:664
 msgid "Start the firewall"
 msgstr ""
 
-#: src/core/system_audit.py:670
+#: src/core/system_audit.py:677
 msgid "nftables"
 msgstr ""
 
-#: src/core/system_audit.py:672
+#: src/core/system_audit.py:679
 msgid "nftables service is active"
 msgstr ""
 
-#: src/core/system_audit.py:683
+#: src/core/system_audit.py:690
 msgid "No active firewall detected"
 msgstr ""
 
-#: src/core/system_audit.py:684
+#: src/core/system_audit.py:691
 msgid "Install and enable a firewall for network protection"
 msgstr ""
 
-#: src/core/system_audit.py:712 src/core/system_audit.py:724
+#: src/core/system_audit.py:719 src/core/system_audit.py:731
 msgid "Firewall Manager"
 msgstr ""
 
-#: src/core/system_audit.py:714
+#: src/core/system_audit.py:721
 #, python-brace-format
 msgid "{name} is available"
 msgstr ""
 
-#: src/core/system_audit.py:716
+#: src/core/system_audit.py:723
 #, python-brace-format
 msgid "Open {name}"
 msgstr ""
 
-#: src/core/system_audit.py:726
+#: src/core/system_audit.py:733
 msgid "No graphical firewall manager detected"
 msgstr ""
 
-#: src/core/system_audit.py:727
+#: src/core/system_audit.py:734
 msgid "Install a GUI for easier firewall management"
 msgstr ""
 
-#: src/core/system_audit.py:814 src/core/system_audit.py:826
-#: src/core/system_audit.py:836
+#: src/core/system_audit.py:821 src/core/system_audit.py:833
+#: src/core/system_audit.py:843
 msgid "Open Ports"
 msgstr ""
 
-#: src/core/system_audit.py:816
+#: src/core/system_audit.py:823
 #, python-brace-format
 msgid "{count} ports listening, risky ports: {ports}"
 msgstr ""
 
-#: src/core/system_audit.py:819
+#: src/core/system_audit.py:826
 msgid "Review if these services need to be exposed"
 msgstr ""
 
-#: src/core/system_audit.py:828
+#: src/core/system_audit.py:835
 #, python-brace-format
 msgid "{count} ports listening"
 msgstr ""
 
-#: src/core/system_audit.py:829
+#: src/core/system_audit.py:836
 msgid "Review open ports and close unnecessary services"
 msgstr ""
 
-#: src/core/system_audit.py:838
+#: src/core/system_audit.py:845
 msgid "No open ports detected"
 msgstr ""
 
-#: src/core/system_audit.py:848 src/ui/audit_view.py:198
+#: src/core/system_audit.py:855 src/ui/audit_view.py:198
 msgid "Access Control"
 msgstr ""
 
-#: src/core/system_audit.py:869
+#: src/core/system_audit.py:876
 msgid "MAC Framework"
 msgstr ""
 
-#: src/core/system_audit.py:871
+#: src/core/system_audit.py:878
 msgid "No mandatory access control framework detected"
 msgstr ""
 
-#: src/core/system_audit.py:872
+#: src/core/system_audit.py:879
 msgid "Consider enabling AppArmor or SELinux"
 msgstr ""
 
-#: src/core/system_audit.py:896 src/core/system_audit.py:903
+#: src/core/system_audit.py:903 src/core/system_audit.py:910
 msgid "AppArmor"
 msgstr ""
 
-#: src/core/system_audit.py:898
+#: src/core/system_audit.py:905
 msgid "AppArmor is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:905
+#: src/core/system_audit.py:912
 msgid "AppArmor module is loaded but not enabled"
 msgstr ""
 
-#: src/core/system_audit.py:906
+#: src/core/system_audit.py:913
 msgid "Enable AppArmor for application sandboxing"
 msgstr ""
 
-#: src/core/system_audit.py:922 src/core/system_audit.py:929
-#: src/core/system_audit.py:937
+#: src/core/system_audit.py:929 src/core/system_audit.py:936
+#: src/core/system_audit.py:944
 msgid "SELinux"
 msgstr ""
 
-#: src/core/system_audit.py:924
+#: src/core/system_audit.py:931
 msgid "SELinux is enforcing"
 msgstr ""
 
-#: src/core/system_audit.py:931
+#: src/core/system_audit.py:938
 msgid "SELinux is in permissive mode"
 msgstr ""
 
-#: src/core/system_audit.py:932
+#: src/core/system_audit.py:939
 msgid "Consider switching to enforcing mode for stronger protection"
 msgstr ""
 
-#: src/core/system_audit.py:939
+#: src/core/system_audit.py:946
 msgid "SELinux is disabled"
 msgstr ""
 
-#: src/core/system_audit.py:940
+#: src/core/system_audit.py:947
 msgid "Enable SELinux for mandatory access control"
 msgstr ""
 
-#: src/core/system_audit.py:963 src/core/system_audit.py:973
+#: src/core/system_audit.py:970 src/core/system_audit.py:980
 msgid "Unattended Upgrades"
 msgstr ""
 
-#: src/core/system_audit.py:965
+#: src/core/system_audit.py:972
 msgid "Automatic security updates are enabled"
 msgstr ""
 
-#: src/core/system_audit.py:975
+#: src/core/system_audit.py:982
 msgid "Unattended upgrades is installed but disabled"
 msgstr ""
 
-#: src/core/system_audit.py:976
+#: src/core/system_audit.py:983
 msgid "Enable automatic security updates"
 msgstr ""
 
-#: src/core/system_audit.py:989 src/core/system_audit.py:1000
+#: src/core/system_audit.py:996 src/core/system_audit.py:1007
 msgid "DNF Automatic"
 msgstr ""
 
-#: src/core/system_audit.py:991
+#: src/core/system_audit.py:998
 msgid "DNF automatic updates are enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1002
+#: src/core/system_audit.py:1009
 msgid "DNF automatic is installed but timer is not active"
 msgstr ""
 
-#: src/core/system_audit.py:1003
+#: src/core/system_audit.py:1010
 msgid "Enable automatic updates"
 msgstr ""
 
-#: src/core/system_audit.py:1022
+#: src/core/system_audit.py:1029
 msgid "Could not determine automatic update status"
 msgstr ""
 
-#: src/core/system_audit.py:1023
+#: src/core/system_audit.py:1030
 msgid "Configure automatic security updates"
 msgstr ""
 
-#: src/core/system_audit.py:1046
+#: src/core/system_audit.py:1053
 msgid "Pending Reboot"
 msgstr ""
 
-#: src/core/system_audit.py:1048
+#: src/core/system_audit.py:1055
 msgid "System reboot required to apply updates"
 msgstr ""
 
-#: src/core/system_audit.py:1049
+#: src/core/system_audit.py:1056
 msgid "Reboot the system to apply pending security updates"
 msgstr ""
 
-#: src/core/system_audit.py:1058 src/ui/audit_view.py:208
+#: src/core/system_audit.py:1065 src/ui/audit_view.py:208
 msgid "Intrusion Detection"
 msgstr ""
 
-#: src/core/system_audit.py:1069 src/core/system_audit.py:1080
+#: src/core/system_audit.py:1076 src/core/system_audit.py:1087
 msgid "fail2ban"
 msgstr ""
 
-#: src/core/system_audit.py:1071
+#: src/core/system_audit.py:1078
 msgid "fail2ban is active and protecting services"
 msgstr ""
 
-#: src/core/system_audit.py:1082
+#: src/core/system_audit.py:1089
 msgid "fail2ban is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1083
+#: src/core/system_audit.py:1090
 msgid "Start fail2ban to protect against brute force attacks"
 msgstr ""
 
-#: src/core/system_audit.py:1095 src/core/system_audit.py:1106
+#: src/core/system_audit.py:1102 src/core/system_audit.py:1113
 msgid "CrowdSec"
 msgstr ""
 
-#: src/core/system_audit.py:1097
+#: src/core/system_audit.py:1104
 msgid "CrowdSec is active with community threat intelligence"
 msgstr ""
 
-#: src/core/system_audit.py:1108
+#: src/core/system_audit.py:1115
 msgid "CrowdSec is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1109
+#: src/core/system_audit.py:1116
 msgid "Start CrowdSec for collaborative intrusion prevention"
 msgstr ""
 
-#: src/core/system_audit.py:1125
+#: src/core/system_audit.py:1132
 msgid "Intrusion Prevention"
 msgstr ""
 
-#: src/core/system_audit.py:1127
+#: src/core/system_audit.py:1134
 msgid "No intrusion detection system found"
 msgstr ""
 
-#: src/core/system_audit.py:1128
+#: src/core/system_audit.py:1135
 msgid "Install fail2ban or CrowdSec to protect against attacks"
 msgstr ""
 
-#: src/core/system_audit.py:1141 src/ui/audit_view.py:211
+#: src/core/system_audit.py:1148 src/ui/audit_view.py:211
 msgid "SSH Security"
 msgstr ""
 
-#: src/core/system_audit.py:1156 src/core/system_audit.py:1166
+#: src/core/system_audit.py:1163 src/core/system_audit.py:1173
 msgid "SSH Server"
 msgstr ""
 
-#: src/core/system_audit.py:1158
+#: src/core/system_audit.py:1165
 msgid "SSH server is not running (no remote attack surface)"
 msgstr ""
 
-#: src/core/system_audit.py:1168
+#: src/core/system_audit.py:1175
 msgid "SSH server is running"
 msgstr ""
 
-#: src/core/system_audit.py:1178
+#: src/core/system_audit.py:1185
 msgid "SSH Configuration"
 msgstr ""
 
-#: src/core/system_audit.py:1180
+#: src/core/system_audit.py:1187
 msgid "Could not read SSH configuration"
 msgstr ""
 
-#: src/core/system_audit.py:1191 src/core/system_audit.py:1200
+#: src/core/system_audit.py:1198 src/core/system_audit.py:1207
 msgid "Root Login"
 msgstr ""
 
-#: src/core/system_audit.py:1193
+#: src/core/system_audit.py:1200
 #, python-brace-format
 msgid "Root login: {value}"
 msgstr ""
 
-#: src/core/system_audit.py:1202
+#: src/core/system_audit.py:1209
 #, python-brace-format
 msgid "Root login is allowed ({value})"
 msgstr ""
 
-#: src/core/system_audit.py:1203
+#: src/core/system_audit.py:1210
 msgid "Disable root SSH login for security"
 msgstr ""
 
-#: src/core/system_audit.py:1213 src/core/system_audit.py:1222
+#: src/core/system_audit.py:1220 src/core/system_audit.py:1229
 msgid "Password Auth"
 msgstr ""
 
-#: src/core/system_audit.py:1215
+#: src/core/system_audit.py:1222
 msgid "Password authentication is disabled (key-only)"
 msgstr ""
 
-#: src/core/system_audit.py:1224
+#: src/core/system_audit.py:1231
 msgid "Password authentication is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1225
+#: src/core/system_audit.py:1232
 msgid "Consider disabling password auth in favor of SSH keys"
 msgstr ""
 
-#: src/core/system_audit.py:1235 src/core/system_audit.py:1244
+#: src/core/system_audit.py:1242 src/core/system_audit.py:1251
 msgid "X11 Forwarding"
 msgstr ""
 
-#: src/core/system_audit.py:1237
+#: src/core/system_audit.py:1244
 msgid "X11 forwarding is disabled"
 msgstr ""
 
-#: src/core/system_audit.py:1246
+#: src/core/system_audit.py:1253
 msgid "X11 forwarding is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1247
+#: src/core/system_audit.py:1254
 msgid "Disable X11 forwarding to reduce attack surface"
 msgstr ""
 
-#: src/core/system_audit.py:1324 src/ui/audit_view.py:272
+#: src/core/system_audit.py:1331 src/ui/audit_view.py:272
 #: src/ui/audit_view.py:307
 msgid "Lynis Security Audit"
 msgstr ""
 
-#: src/core/system_audit.py:1333
+#: src/core/system_audit.py:1340
 msgid "Lynis"
 msgstr ""
 
-#: src/core/system_audit.py:1335
+#: src/core/system_audit.py:1342
 msgid "Lynis is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:1336
+#: src/core/system_audit.py:1343
 msgid "Install Lynis for comprehensive security auditing"
 msgstr ""
 
-#: src/core/system_audit.py:1364 src/core/system_audit.py:1374
-#: src/core/system_audit.py:1386 src/core/system_audit.py:1418
+#: src/core/system_audit.py:1371 src/core/system_audit.py:1381
+#: src/core/system_audit.py:1393 src/core/system_audit.py:1425
 msgid "Lynis Audit"
 msgstr ""
 
-#: src/core/system_audit.py:1366
+#: src/core/system_audit.py:1373
 msgid "Lynis audit timed out after 5 minutes"
 msgstr ""
 
-#: src/core/system_audit.py:1376
+#: src/core/system_audit.py:1383
 #, python-brace-format
 msgid "Failed to run Lynis: {error}"
 msgstr ""
 
-#: src/core/system_audit.py:1388 src/core/system_audit.py:1516
+#: src/core/system_audit.py:1395 src/core/system_audit.py:1523
 msgid "Authentication was cancelled"
 msgstr ""
 
-#: src/core/system_audit.py:1406
+#: src/core/system_audit.py:1413
 msgid "Hardening Index"
 msgstr ""
 
-#: src/core/system_audit.py:1408
+#: src/core/system_audit.py:1415
 #, python-brace-format
 msgid "Score: {score}/100"
 msgstr ""
 
-#: src/core/system_audit.py:1409
+#: src/core/system_audit.py:1416
 msgid "Run 'sudo lynis audit system' for detailed recommendations"
 msgstr ""
 
-#: src/core/system_audit.py:1420
+#: src/core/system_audit.py:1427
 #, python-brace-format
 msgid "Audit completed (exit code {code})"
 msgstr ""
 
-#: src/core/system_audit.py:1461 src/ui/audit_view.py:278
+#: src/core/system_audit.py:1468 src/ui/audit_view.py:278
 #: src/ui/audit_view.py:310
 msgid "Rootkit Detection"
 msgstr ""
 
-#: src/core/system_audit.py:1470
+#: src/core/system_audit.py:1477
 msgid "chkrootkit"
 msgstr ""
 
-#: src/core/system_audit.py:1472
+#: src/core/system_audit.py:1479
 msgid "chkrootkit is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:1473
+#: src/core/system_audit.py:1480
 msgid "Install chkrootkit for rootkit detection"
 msgstr ""
 
-#: src/core/system_audit.py:1492 src/core/system_audit.py:1502
-#: src/core/system_audit.py:1514 src/core/system_audit.py:1534
-#: src/core/system_audit.py:1554 src/core/system_audit.py:1574
+#: src/core/system_audit.py:1499 src/core/system_audit.py:1509
+#: src/core/system_audit.py:1521 src/core/system_audit.py:1541
+#: src/core/system_audit.py:1561 src/core/system_audit.py:1581
 msgid "Rootkit Scan"
 msgstr ""
 
-#: src/core/system_audit.py:1494
+#: src/core/system_audit.py:1501
 msgid "Rootkit scan timed out after 5 minutes"
 msgstr ""
 
-#: src/core/system_audit.py:1504
+#: src/core/system_audit.py:1511
 #, python-brace-format
 msgid "Failed to run chkrootkit: {error}"
 msgstr ""
 
-#: src/core/system_audit.py:1527
+#: src/core/system_audit.py:1534
 #, python-brace-format
 msgid "Rootkit scan could not be completed (exit {code})"
 msgstr ""
 
-#: src/core/system_audit.py:1556
+#: src/core/system_audit.py:1563
 #, python-brace-format
 msgid "{count} potential rootkit(s) detected"
 msgstr ""
 
-#: src/core/system_audit.py:1557
+#: src/core/system_audit.py:1564
 msgid "Investigate the detected threats immediately"
 msgstr ""
 
-#: src/core/system_audit.py:1565
+#: src/core/system_audit.py:1572
 msgid "Finding"
 msgstr ""
 
-#: src/core/system_audit.py:1576
+#: src/core/system_audit.py:1583
 msgid "No rootkits detected"
 msgstr ""
 
-#: src/core/system_audit.py:1611 src/core/system_audit.py:1628
-#: src/core/system_audit.py:1663 src/core/system_audit.py:1674
-#: src/core/system_audit.py:1683 src/ui/audit_view.py:212
+#: src/core/system_audit.py:1618 src/core/system_audit.py:1635
+#: src/core/system_audit.py:1670 src/core/system_audit.py:1681
+#: src/core/system_audit.py:1690 src/ui/audit_view.py:212
 #: src/ui/audit_view.py:561
 msgid "Portmaster"
 msgstr ""
 
-#: src/core/system_audit.py:1630
+#: src/core/system_audit.py:1637
 msgid "Portmaster is running and protecting connections"
 msgstr ""
 
-#: src/core/system_audit.py:1652
+#: src/core/system_audit.py:1659
 msgid "Module Status"
 msgstr ""
 
-#: src/core/system_audit.py:1654
+#: src/core/system_audit.py:1661
 msgid "Authorize ClamUI in Portmaster for per-module health"
 msgstr ""
 
-#: src/core/system_audit.py:1656
+#: src/core/system_audit.py:1663
 msgid "Authorize"
 msgstr ""
 
-#: src/core/system_audit.py:1665
+#: src/core/system_audit.py:1672
 msgid "Portmaster is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1666
+#: src/core/system_audit.py:1673
 msgid "Start the Portmaster service to enable network protection"
 msgstr ""
 
-#: src/core/system_audit.py:1676
+#: src/core/system_audit.py:1683
 msgid "Not detected — optional network monitor and application firewall"
 msgstr ""
 
-#: src/core/system_audit.py:1685
+#: src/core/system_audit.py:1692
 #, python-brace-format
 msgid "Could not probe Portmaster: {error}"
 msgstr ""
@@ -1709,7 +1796,7 @@ msgstr ""
 
 #: src/core/file_manager_integration.py:481
 #: src/core/file_manager_integration.py:567
-#: src/core/file_manager_integration.py:616 src/core/updater.py:565
+#: src/core/file_manager_integration.py:616 src/core/updater.py:572
 #, python-brace-format
 msgid "Permission denied: {error}"
 msgstr ""
@@ -1782,7 +1869,7 @@ msgstr ""
 msgid "Unknown Device"
 msgstr ""
 
-#: src/core/notification_manager.py:79 src/ui/scan_results_dialog.py:185
+#: src/core/notification_manager.py:79 src/ui/scan_results_dialog.py:186
 msgid "Scan Complete"
 msgstr ""
 
@@ -1794,7 +1881,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/core/notification_manager.py:87 src/core/notification_manager.py:175
-#: src/ui/scan_results_dialog.py:193
+#: src/ui/scan_results_dialog.py:194
 msgid "No threats found"
 msgstr ""
 
@@ -1972,7 +2059,7 @@ msgstr ""
 msgid "Scanned Path: {path}"
 msgstr ""
 
-#: src/core/result_formatters.py:82 src/ui/logs_view.py:773
+#: src/core/result_formatters.py:82 src/ui/logs_view.py:785
 #, python-brace-format
 msgid "Status: {status}"
 msgstr ""
@@ -1982,7 +2069,7 @@ msgstr ""
 msgid "Directories Scanned: {count}"
 msgstr ""
 
-#: src/core/result_formatters.py:97 src/ui/scan_results_dialog.py:335
+#: src/core/result_formatters.py:97 src/ui/scan_results_dialog.py:336
 msgid "Detected Threats"
 msgstr ""
 
@@ -2009,11 +2096,6 @@ msgstr ""
 msgid "All scanned files are clean."
 msgstr ""
 
-#: src/core/result_formatters.py:124 src/ui/update_view.py:678
-#, python-brace-format
-msgid "Error: {message}"
-msgstr ""
-
 #: src/core/result_formatters.py:131
 msgid "The scan was cancelled before completion."
 msgstr ""
@@ -2038,180 +2120,180 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: src/core/scanner_base.py:617
+#: src/core/scanner_base.py:621
 msgid "Scan cancelled by user"
 msgstr ""
 
-#: src/core/updater.py:234
+#: src/core/updater.py:241
 #, python-brace-format
 msgid "Freshclam service not running (status: {status})"
 msgstr ""
 
-#: src/core/updater.py:250
+#: src/core/updater.py:257
 msgid "Could not determine freshclam PID"
 msgstr ""
 
-#: src/core/updater.py:252
+#: src/core/updater.py:259
 #, python-brace-format
 msgid "Failed to get freshclam PID: {error}"
 msgstr ""
 
-#: src/core/updater.py:266 src/core/updater.py:286
+#: src/core/updater.py:273 src/core/updater.py:293
 #, python-brace-format
 msgid "Update signal sent to freshclam service (PID {pid})"
 msgstr ""
 
-#: src/core/updater.py:291 src/core/updater.py:301
+#: src/core/updater.py:298 src/core/updater.py:308
 #, python-brace-format
 msgid "Failed to send signal: {error}"
 msgstr ""
 
-#: src/core/updater.py:295
+#: src/core/updater.py:302
 msgid "Timeout sending elevated signal to freshclam"
 msgstr ""
 
-#: src/core/updater.py:304
+#: src/core/updater.py:311
 msgid "Timeout sending signal to freshclam"
 msgstr ""
 
-#: src/core/updater.py:306
+#: src/core/updater.py:313
 #, python-brace-format
 msgid "Error sending signal: {error}"
 msgstr ""
 
-#: src/core/updater.py:411
+#: src/core/updater.py:418
 msgid ""
 "Could not trigger freshclam service update. Try restarting the service: sudo "
 "systemctl restart clamav-freshclam"
 msgstr ""
 
-#: src/core/updater.py:445
+#: src/core/updater.py:452
 msgid "Delete failed"
 msgstr ""
 
-#: src/core/updater.py:464
+#: src/core/updater.py:471
 #, python-brace-format
 msgid ""
 "Another freshclam instance is running (PID {pid}). Stop it first: sudo "
 "systemctl stop clamav-freshclam"
 msgstr ""
 
-#: src/core/updater.py:575
+#: src/core/updater.py:582
 #, python-brace-format
 msgid "Update failed: {error}"
 msgstr ""
 
-#: src/core/updater.py:587
+#: src/core/updater.py:594
 msgid "Update timed out after 10 minutes"
 msgstr ""
 
-#: src/core/updater.py:600
+#: src/core/updater.py:607
 msgid "Update cancelled by user"
 msgstr ""
 
-#: src/core/updater.py:920 src/ui/update_view.py:657
+#: src/core/updater.py:927 src/ui/update_view.py:661
 #, python-brace-format
 msgid "{database} until {cooldown}"
 msgstr ""
 
-#: src/core/updater.py:957
+#: src/core/updater.py:964
 msgid ""
 "Authentication cancelled. Database update requires administrator privileges."
 msgstr ""
 
-#: src/core/updater.py:959
+#: src/core/updater.py:966
 msgid "Authorization failed. You are not authorized to update the database."
 msgstr ""
 
-#: src/core/updater.py:966
+#: src/core/updater.py:973
 #, python-brace-format
 msgid "Updated: {databases}"
 msgstr ""
 
-#: src/core/updater.py:972
+#: src/core/updater.py:979
 #, python-brace-format
 msgid "Already current: {databases}"
 msgstr ""
 
-#: src/core/updater.py:979
+#: src/core/updater.py:986
 #, python-brace-format
 msgid ""
 "Database update partially completed. {progress}. Rate limited: {details}."
 msgstr ""
 
-#: src/core/updater.py:982
+#: src/core/updater.py:989
 #, python-brace-format
 msgid "Update rate limited for: {details}."
 msgstr ""
 
-#: src/core/updater.py:986
+#: src/core/updater.py:993
 msgid "Update rate limited by mirror. Please wait a few minutes and try again."
 msgstr ""
 
-#: src/core/updater.py:991
+#: src/core/updater.py:998
 msgid ""
 "Update blocked by CDN. This may be due to rate limiting. Please wait and try "
 "again later."
 msgstr ""
 
-#: src/core/updater.py:997
+#: src/core/updater.py:1004
 msgid "ClamAV mirror is currently unavailable. Please try again later."
 msgstr ""
 
-#: src/core/updater.py:1003
+#: src/core/updater.py:1010
 msgid "SSL/TLS certificate error. The mirror may have configuration issues."
 msgstr ""
 
-#: src/core/updater.py:1007
+#: src/core/updater.py:1014
 msgid "Connection timed out. Please check your network connection."
 msgstr ""
 
-#: src/core/updater.py:1011
+#: src/core/updater.py:1018
 msgid "Authorization failed. Please try again and enter your password."
 msgstr ""
 
-#: src/core/updater.py:1015
+#: src/core/updater.py:1022
 msgid "Database is locked. Another freshclam instance may be running."
 msgstr ""
 
-#: src/core/updater.py:1019
+#: src/core/updater.py:1026
 msgid ""
 "Permission denied. You may need elevated privileges to update the database."
 msgstr ""
 
-#: src/core/updater.py:1023
+#: src/core/updater.py:1030
 msgid "Connection error. Please check your network connection."
 msgstr ""
 
-#: src/core/updater.py:1027
+#: src/core/updater.py:1034
 msgid "DNS resolution failed. Please check your network settings."
 msgstr ""
 
-#: src/core/updater.py:1033
+#: src/core/updater.py:1040
 msgid "Update failed with an unknown error. Check the logs for details."
 msgstr ""
 
-#: src/core/updater.py:1045
+#: src/core/updater.py:1052
 #, python-brace-format
 msgid "Database update completed - {count} database(s) updated"
 msgstr ""
 
-#: src/core/updater.py:1049
+#: src/core/updater.py:1056
 msgid "Database update completed - Already up to date"
 msgstr ""
 
-#: src/core/updater.py:1051
+#: src/core/updater.py:1058
 msgid "Database update cancelled"
 msgstr ""
 
-#: src/core/updater.py:1053
+#: src/core/updater.py:1060
 #, python-brace-format
 msgid "Database update failed: {error}"
 msgstr ""
 
-#: src/core/updater.py:1054 src/ui/scan_results_dialog.py:224
+#: src/core/updater.py:1061 src/ui/scan_results_dialog.py:225
 #: src/ui/scan_view.py:645 src/ui/scan_view.py:2263
-#: src/ui/virustotal_results_dialog.py:197
+#: src/ui/virustotal_results_dialog.py:198
 msgid "Unknown error"
 msgstr ""
 
@@ -2227,7 +2309,7 @@ msgid "API rate limit exceeded"
 msgstr ""
 
 #: src/core/virustotal.py:274 src/ui/preferences/virustotal_page.py:291
-#: src/ui/virustotal_setup_dialog.py:274
+#: src/ui/virustotal_setup_dialog.py:275
 msgid "Invalid API key"
 msgstr ""
 
@@ -2326,7 +2408,7 @@ msgstr ""
 msgid "Copied to clipboard"
 msgstr ""
 
-#: src/ui/clipboard_helper.py:101
+#: src/ui/clipboard_helper.py:101 src/ui/logs_view.py:891
 msgid "Failed to copy to clipboard"
 msgstr ""
 
@@ -2339,44 +2421,46 @@ msgstr ""
 msgid "Content too large ({size}). Use export to save to file."
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:68
+#: src/ui/close_behavior_dialog.py:69
 msgid "Close Application?"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:96
+#: src/ui/close_behavior_dialog.py:98
 msgid "What would you like to do when closing the window?"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:106 src/ui/preferences/behavior_page.py:40
+#: src/ui/close_behavior_dialog.py:108 src/ui/preferences/behavior_page.py:40
 msgid "Minimize to tray"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:108
+#: src/ui/close_behavior_dialog.py:110
 msgid "Hide the window but keep ClamUI running in the background"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:122 src/ui/preferences/behavior_page.py:41
+#: src/ui/close_behavior_dialog.py:124 src/ui/preferences/behavior_page.py:41
 msgid "Quit completely"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:123
+#: src/ui/close_behavior_dialog.py:125
 msgid "Close the window and exit ClamUI"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:142 src/ui/virustotal_setup_dialog.py:222
+#: src/ui/close_behavior_dialog.py:144 src/ui/virustotal_setup_dialog.py:223
 msgid "Remember my choice"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:153 src/ui/database_missing_dialog.py:132
-#: src/ui/file_manager_integration_dialog.py:261 src/ui/logs_view.py:100
-#: src/ui/preferences/virustotal_page.py:359 src/ui/profile_dialogs.py:121
-#: src/ui/profile_dialogs.py:721 src/ui/profile_dialogs.py:867
-#: src/ui/profile_dialogs.py:988 src/ui/scan/scan_view.py:168
-#: src/ui/scan_view.py:1260 src/ui/scan_view.py:1906 src/ui/update_view.py:145
+#: src/ui/close_behavior_dialog.py:155 src/ui/database_missing_dialog.py:133
+#: src/ui/file_manager_integration_dialog.py:262 src/ui/logs_view.py:108
+#: src/ui/preferences/debug_page.py:712
+#: src/ui/preferences/virustotal_page.py:359 src/ui/profile_dialogs.py:123
+#: src/ui/profile_dialogs.py:724 src/ui/profile_dialogs.py:873
+#: src/ui/profile_dialogs.py:995 src/ui/quarantine_view.py:100
+#: src/ui/scan/scan_view.py:168 src/ui/scan_view.py:1260
+#: src/ui/scan_view.py:1906 src/ui/update_view.py:145
 msgid "Cancel"
 msgstr ""
 
-#: src/ui/close_behavior_dialog.py:158
+#: src/ui/close_behavior_dialog.py:160
 msgid "Confirm"
 msgstr ""
 
@@ -2384,13 +2468,13 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: src/ui/compat.py:426 src/ui/compat.py:492
+#: src/ui/compat.py:426 src/ui/compat.py:492 src/ui/file_export.py:190
 #: src/ui/preferences/database_page.py:336
 #: src/ui/preferences/scanner_page.py:239
 msgid "_Cancel"
 msgstr ""
 
-#: src/ui/compat.py:491
+#: src/ui/compat.py:491 src/ui/file_export.py:189
 msgid "_Save"
 msgstr ""
 
@@ -2407,7 +2491,7 @@ msgid "Refresh Audit"
 msgstr ""
 
 #: src/ui/audit_view.py:236 src/ui/audit_view.py:789
-#: src/ui/components_view.py:239 src/ui/logs_view.py:509
+#: src/ui/components_view.py:243 src/ui/logs_view.py:521
 #: src/ui/statistics_view.py:185
 msgid "Checking..."
 msgstr ""
@@ -2466,8 +2550,8 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/ui/audit_view.py:657 src/ui/components_view.py:357
-#: src/ui/logs_view.py:389
+#: src/ui/audit_view.py:657 src/ui/components_view.py:370
+#: src/ui/logs_view.py:401
 msgid "Copy to clipboard"
 msgstr ""
 
@@ -2510,125 +2594,125 @@ msgid ""
 "updates:"
 msgstr ""
 
-#: src/ui/components_view.py:58
+#: src/ui/components_view.py:59
 msgid "clamdscan Installation"
 msgstr ""
 
-#: src/ui/components_view.py:65
+#: src/ui/components_view.py:66
 msgid ""
 "clamdscan is a client for the clamd daemon, providing faster scanning. "
 "Requires clamd daemon to be running."
 msgstr ""
 
-#: src/ui/components_view.py:69
+#: src/ui/components_view.py:70
 msgid "clamd Daemon Setup"
 msgstr ""
 
-#: src/ui/components_view.py:84
+#: src/ui/components_view.py:89
 msgid "clamd is the ClamAV daemon for faster scanning."
 msgstr ""
 
-#: src/ui/components_view.py:86
+#: src/ui/components_view.py:90
 msgid "Configuration file location is auto-detected in Preferences."
 msgstr ""
 
-#: src/ui/components_view.py:89
+#: src/ui/components_view.py:92
 msgid ""
 "On Fedora, ClamUI uses /etc/clamd.d/scan.conf. If the daemon is running but "
 "still unavailable, verify socket permissions and test with: clamdscan --"
 "config-file=/etc/clamd.d/scan.conf --ping 3"
 msgstr ""
 
-#: src/ui/components_view.py:157
+#: src/ui/components_view.py:161
 msgid "ClamAV Components"
 msgstr ""
 
-#: src/ui/components_view.py:159
+#: src/ui/components_view.py:163
 msgid "Check the status of ClamAV components and get setup instructions"
 msgstr ""
 
-#: src/ui/components_view.py:164
+#: src/ui/components_view.py:168
 msgid "Component Status"
 msgstr ""
 
-#: src/ui/components_view.py:165
+#: src/ui/components_view.py:169
 msgid "View installation status and setup guides for ClamAV tools"
 msgstr ""
 
-#: src/ui/components_view.py:180
+#: src/ui/components_view.py:184
 msgid "Components Status"
 msgstr ""
 
-#: src/ui/components_view.py:185
+#: src/ui/components_view.py:189
 msgid ""
 "ClamAV tools must be installed on the host system. Flatpak runs them through "
 "flatpak-spawn."
 msgstr ""
 
-#: src/ui/components_view.py:191
+#: src/ui/components_view.py:195
 msgid "Expand each component for installation instructions"
 msgstr ""
 
-#: src/ui/components_view.py:200
+#: src/ui/components_view.py:204
 msgid "Virus Scanner"
 msgstr ""
 
-#: src/ui/components_view.py:205
+#: src/ui/components_view.py:209
 msgid "Database Updater"
 msgstr ""
 
-#: src/ui/components_view.py:214
+#: src/ui/components_view.py:218
 msgid "Daemon Scanner Client"
 msgstr ""
 
-#: src/ui/components_view.py:218
+#: src/ui/components_view.py:222
 msgid "Scanner Daemon"
 msgstr ""
 
-#: src/ui/components_view.py:251
+#: src/ui/components_view.py:255
 msgid "Checking"
 msgstr ""
 
-#: src/ui/components_view.py:407 src/ui/preferences/scanner_page.py:342
+#: src/ui/components_view.py:420 src/ui/preferences/scanner_page.py:342
 msgid "Refresh Status"
 msgstr ""
 
-#: src/ui/components_view.py:535 src/ui/components_view.py:536
+#: src/ui/components_view.py:548 src/ui/components_view.py:549
 msgid "Installed"
 msgstr ""
 
-#: src/ui/components_view.py:546 src/ui/components_view.py:597
-#: src/ui/logs_view.py:1249
+#: src/ui/components_view.py:559 src/ui/components_view.py:610
+#: src/ui/logs_view.py:1275
 msgid "Not installed"
 msgstr ""
 
-#: src/ui/components_view.py:547 src/ui/components_view.py:598
+#: src/ui/components_view.py:560 src/ui/components_view.py:611
 msgid "Not installed - expand for setup instructions"
 msgstr ""
 
-#: src/ui/components_view.py:579 src/ui/logs_view.py:1236
+#: src/ui/components_view.py:592 src/ui/logs_view.py:1262
 msgid "Running"
 msgstr ""
 
-#: src/ui/components_view.py:580
+#: src/ui/components_view.py:593
 msgid "Daemon is running"
 msgstr ""
 
-#: src/ui/components_view.py:588 src/ui/logs_view.py:1243
+#: src/ui/components_view.py:601 src/ui/logs_view.py:1269
 msgid "Stopped"
 msgstr ""
 
-#: src/ui/components_view.py:589
+#: src/ui/components_view.py:602
 msgid "Daemon is installed but not running"
 msgstr ""
 
-#: src/ui/components_view.py:605 src/ui/logs_view.py:1264
-#: src/ui/quarantine_view.py:696 src/ui/statistics_view.py:190
+#: src/ui/components_view.py:618 src/ui/logs_view.py:1290
+#: src/ui/quarantine_view.py:788 src/ui/statistics_view.py:190
 #: src/ui/statistics_view.py:806 src/ui/statistics_view.py:835
 msgid "Unknown"
 msgstr ""
 
-#: src/ui/components_view.py:606 src/ui/statistics_view.py:802
+#: src/ui/components_view.py:619 src/ui/statistics_view.py:802
 #: src/ui/statistics_view.py:990
 msgid "Unable to determine status"
 msgstr ""
@@ -2637,17 +2721,17 @@ msgstr ""
 msgid "Virus Database Required"
 msgstr ""
 
-#: src/ui/database_missing_dialog.py:107
+#: src/ui/database_missing_dialog.py:108
 msgid "<b>Virus Database Not Found</b>"
 msgstr ""
 
-#: src/ui/database_missing_dialog.py:116
+#: src/ui/database_missing_dialog.py:117
 msgid ""
 "ClamAV requires a virus database to scan files. The database needs to be "
 "downloaded before you can perform scans."
 msgstr ""
 
-#: src/ui/database_missing_dialog.py:137
+#: src/ui/database_missing_dialog.py:138
 msgid "Download Now"
 msgstr ""
 
@@ -2682,8 +2766,8 @@ msgstr ""
 msgid "CSV Files"
 msgstr ""
 
-#: src/ui/file_export.py:287 src/ui/profile_dialogs.py:1343
-#: src/ui/profile_dialogs.py:1394
+#: src/ui/file_export.py:287 src/ui/profile_dialogs.py:1357
+#: src/ui/profile_dialogs.py:1411
 msgid "JSON Files"
 msgstr ""
 
@@ -2692,265 +2776,312 @@ msgstr ""
 msgid "File Manager Integration"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:132
+#: src/ui/file_manager_integration_dialog.py:133
 msgid "Add Context Menu Actions"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:135
+#: src/ui/file_manager_integration_dialog.py:136
 msgid ""
 "ClamUI can add 'Scan with ClamUI' options to your file manager's right-click "
 "menu. This makes it easy to scan files and folders directly from your file "
 "browser."
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:143
+#: src/ui/file_manager_integration_dialog.py:144
 msgid "What gets installed?"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:146
+#: src/ui/file_manager_integration_dialog.py:147
 msgid ""
 "Small configuration files are added to your user profile. No system files "
 "are modified."
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:161
+#: src/ui/file_manager_integration_dialog.py:162
 msgid "Available File Managers"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:162
+#: src/ui/file_manager_integration_dialog.py:163
 msgid "Select which file managers to integrate with:"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:179
+#: src/ui/file_manager_integration_dialog.py:180
 msgid "No supported file managers detected"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:180
+#: src/ui/file_manager_integration_dialog.py:181
 msgid "ClamUI supports Nemo, Nautilus, and Dolphin file managers."
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:210
+#: src/ui/file_manager_integration_dialog.py:211
 #, python-brace-format
 msgid "{description} (installed)"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:215
+#: src/ui/file_manager_integration_dialog.py:216
 #, python-brace-format
 msgid "{description} (incomplete - needs repair)"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:267
+#: src/ui/file_manager_integration_dialog.py:268
 msgid "Apply"
-msgstr ""
-
-#: src/ui/file_manager_integration_dialog.py:337
-#, python-brace-format
-msgid "{count} succeeded"
 msgstr ""
 
 #: src/ui/file_manager_integration_dialog.py:338
 #, python-brace-format
+msgid "{count} succeeded"
+msgstr ""
+
+#: src/ui/file_manager_integration_dialog.py:339
+#, python-brace-format
 msgid "{count} failed"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:343
+#: src/ui/file_manager_integration_dialog.py:344
 #, python-brace-format
 msgid "{count} installed"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:345
+#: src/ui/file_manager_integration_dialog.py:346
 #, python-brace-format
 msgid "{count} removed"
 msgstr ""
 
-#: src/ui/file_manager_integration_dialog.py:347
+#: src/ui/file_manager_integration_dialog.py:348
 #, python-brace-format
 msgid "{count} repaired"
 msgstr ""
 
-#: src/ui/fullscreen_dialog.py:36
+#: src/ui/fullscreen_dialog.py:37
 msgid "No content to display"
 msgstr ""
 
-#: src/ui/logs_view.py:49
+#: src/ui/logs_view.py:56
 msgid "Clear All Logs?"
 msgstr ""
 
-#: src/ui/logs_view.py:51
+#: src/ui/logs_view.py:58
 msgid ""
 "This will permanently delete all historical logs. This action cannot be "
 "undone."
 msgstr ""
 
-#: src/ui/logs_view.py:105 src/ui/logs_view.py:288
+#: src/ui/logs_view.py:113 src/ui/logs_view.py:300
 #: src/ui/scan/target_selector.py:107
 msgid "Clear All"
 msgstr ""
 
-#: src/ui/logs_view.py:243 src/ui/logs_view.py:279
+#: src/ui/logs_view.py:255 src/ui/logs_view.py:291
 msgid "Historical Logs"
 msgstr ""
 
-#: src/ui/logs_view.py:280
+#: src/ui/logs_view.py:292
 msgid "Previous scan and update operations"
 msgstr ""
 
-#: src/ui/logs_view.py:296
+#: src/ui/logs_view.py:308
 msgid "Export all logs to JSON"
 msgstr ""
 
-#: src/ui/logs_view.py:305
+#: src/ui/logs_view.py:317
 msgid "Export all logs to CSV"
 msgstr ""
 
-#: src/ui/logs_view.py:314
+#: src/ui/logs_view.py:326
 msgid "Refresh logs"
 msgstr ""
 
-#: src/ui/logs_view.py:354
+#: src/ui/logs_view.py:366
 msgid "No logs yet"
 msgstr ""
 
-#: src/ui/logs_view.py:355
+#: src/ui/logs_view.py:367
 msgid "Logs from scans and updates will appear here"
 msgstr ""
 
-#: src/ui/logs_view.py:366
+#: src/ui/logs_view.py:378
 msgid "Loading logs..."
 msgstr ""
 
-#: src/ui/logs_view.py:377 src/ui/logs_view.py:854
+#: src/ui/logs_view.py:389 src/ui/logs_view.py:866
 msgid "Log Details"
 msgstr ""
 
-#: src/ui/logs_view.py:378
+#: src/ui/logs_view.py:390
 msgid "Select a log entry above to view details"
 msgstr ""
 
-#: src/ui/logs_view.py:398
+#: src/ui/logs_view.py:410
 msgid "Export to text file"
 msgstr ""
 
-#: src/ui/logs_view.py:407
+#: src/ui/logs_view.py:419
 msgid "Export to CSV file"
 msgstr ""
 
-#: src/ui/logs_view.py:416
+#: src/ui/logs_view.py:428
 msgid "Export to JSON file"
 msgstr ""
 
-#: src/ui/logs_view.py:425 src/ui/logs_view.py:497
+#: src/ui/logs_view.py:437 src/ui/logs_view.py:509
 msgid "View fullscreen"
 msgstr ""
 
-#: src/ui/logs_view.py:460 src/ui/logs_view.py:729 src/ui/logs_view.py:1179
+#: src/ui/logs_view.py:472 src/ui/logs_view.py:741 src/ui/logs_view.py:1191
 msgid "Select a log entry to view details."
 msgstr ""
 
-#: src/ui/logs_view.py:477
+#: src/ui/logs_view.py:489
 msgid "ClamAV Daemon Logs"
 msgstr ""
 
-#: src/ui/logs_view.py:478
+#: src/ui/logs_view.py:490
 msgid "Live logs from the clamd daemon"
 msgstr ""
 
-#: src/ui/logs_view.py:488
+#: src/ui/logs_view.py:500
 msgid "Export daemon logs to file"
 msgstr ""
 
-#: src/ui/logs_view.py:508 src/ui/preferences/scanner_page.py:322
+#: src/ui/logs_view.py:520 src/ui/preferences/scanner_page.py:322
 msgid "Daemon Status"
 msgstr ""
 
-#: src/ui/logs_view.py:515 src/ui/logs_view.py:1282
+#: src/ui/logs_view.py:527 src/ui/logs_view.py:1308
 msgid "Start live log updates"
 msgstr ""
 
-#: src/ui/logs_view.py:542
+#: src/ui/logs_view.py:554
 msgid "Daemon logs will appear here."
 msgstr ""
 
-#: src/ui/logs_view.py:544
+#: src/ui/logs_view.py:556
 msgid "Click the play button to start live updates."
 msgstr ""
 
-#: src/ui/logs_view.py:762
+#: src/ui/logs_view.py:614 src/ui/logs_view.py:667 src/ui/logs_view.py:672
+msgid "logs"
+msgstr ""
+
+#: src/ui/logs_view.py:774
 msgid "SCAN LOG"
 msgstr ""
 
-#: src/ui/logs_view.py:764
+#: src/ui/logs_view.py:776
 msgid "UPDATE LOG"
 msgstr ""
 
-#: src/ui/logs_view.py:770
+#: src/ui/logs_view.py:782
 #, python-brace-format
 msgid "ID: {id}"
 msgstr ""
 
-#: src/ui/logs_view.py:771
+#: src/ui/logs_view.py:783
 #, python-brace-format
 msgid "Timestamp: {timestamp}"
 msgstr ""
 
-#: src/ui/logs_view.py:772
+#: src/ui/logs_view.py:784
 #, python-brace-format
 msgid "Type: {type}"
 msgstr ""
 
-#: src/ui/logs_view.py:776 src/ui/quarantine_view.py:675
+#: src/ui/logs_view.py:788 src/ui/quarantine_view.py:767
 #, python-brace-format
 msgid "Path: {path}"
 msgstr ""
 
-#: src/ui/logs_view.py:779
+#: src/ui/logs_view.py:791
 #, python-brace-format
 msgid "Duration: {duration:.2f} seconds"
 msgstr ""
 
-#: src/ui/logs_view.py:793
+#: src/ui/logs_view.py:805
 msgid "Statistics Summary:"
 msgstr ""
 
-#: src/ui/logs_view.py:798
+#: src/ui/logs_view.py:810
 #, python-brace-format
 msgid "  Files Scanned: {count}"
 msgstr ""
 
-#: src/ui/logs_view.py:805
+#: src/ui/logs_view.py:817
 #, python-brace-format
 msgid "  Directories Scanned: {count}"
 msgstr ""
 
-#: src/ui/logs_view.py:814
+#: src/ui/logs_view.py:826
 #, python-brace-format
 msgid "{seconds:.2f} seconds"
 msgstr ""
 
-#: src/ui/logs_view.py:818
+#: src/ui/logs_view.py:830
 #, python-brace-format
 msgid "{minutes}m {seconds:.0f}s"
 msgstr ""
 
-#: src/ui/logs_view.py:824 src/ui/statistics_view.py:1030
+#: src/ui/logs_view.py:836 src/ui/statistics_view.py:1030
 #, python-brace-format
 msgid "{hours}h {minutes}m"
 msgstr ""
 
-#: src/ui/logs_view.py:825
+#: src/ui/logs_view.py:837
 #, python-brace-format
 msgid "  Duration: {duration}"
 msgstr ""
 
-#: src/ui/logs_view.py:830 src/ui/scan_view.py:665 src/ui/update_view.py:635
+#: src/ui/logs_view.py:842 src/ui/scan_view.py:665 src/ui/update_view.py:639
 msgid "Summary:"
 msgstr ""
 
-#: src/ui/logs_view.py:837
+#: src/ui/logs_view.py:849
 msgid "Full Output:"
 msgstr ""
 
-#: src/ui/logs_view.py:1258
+#: src/ui/logs_view.py:890
+msgid "Log details copied to clipboard"
+msgstr ""
+
+#: src/ui/logs_view.py:907
+msgid "Export Log Details"
+msgstr ""
+
+#: src/ui/logs_view.py:926
+msgid "Export Log Details as CSV"
+msgstr ""
+
+#: src/ui/logs_view.py:945
+msgid "Export Log Details as JSON"
+msgstr ""
+
+#: src/ui/logs_view.py:1101
+msgid "Daemon Logs"
+msgstr ""
+
+#: src/ui/logs_view.py:1119
+msgid "Export Daemon Logs"
+msgstr ""
+
+#: src/ui/logs_view.py:1123
+msgid "Exported daemon logs"
+msgstr ""
+
+#: src/ui/logs_view.py:1140
+msgid "Export All Logs to CSV"
+msgstr ""
+
+#: src/ui/logs_view.py:1144 src/ui/logs_view.py:1165
+#, python-brace-format
+msgid "Exported {n} log"
+msgid_plural "Exported {n} logs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/ui/logs_view.py:1161
+msgid "Export All Logs to JSON"
+msgstr ""
+
+#: src/ui/logs_view.py:1284
 msgid ""
 "ClamAV daemon (clamd) is not installed.\n"
 "\n"
@@ -2958,21 +3089,30 @@ msgid ""
 "You can still use ClamUI for on-demand scanning without it."
 msgstr ""
 
-#: src/ui/logs_view.py:1277
+#: src/ui/logs_view.py:1303
 msgid "Stop live log updates"
 msgstr ""
 
-#: src/ui/pagination.py:179
+#: src/ui/logs_view.py:1358
+msgid "Error loading daemon logs:"
+msgstr ""
+
+#: src/ui/pagination.py:169 src/ui/quarantine_view.py:443
+#: src/ui/quarantine_view.py:630
+msgid "entries"
+msgstr ""
+
+#: src/ui/pagination.py:182
 #, python-brace-format
 msgid "Showing {displayed} of {total} {label}"
 msgstr ""
 
-#: src/ui/pagination.py:195
+#: src/ui/pagination.py:198
 #, python-brace-format
 msgid "Show {count} More"
 msgstr ""
 
-#: src/ui/pagination.py:205
+#: src/ui/pagination.py:208
 #, python-brace-format
 msgid "Show All ({remaining} remaining)"
 msgstr ""
@@ -3287,7 +3427,7 @@ msgid "Paste URL or multi-line config block"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:507
-#: src/ui/preferences/exclusions_page.py:130 src/ui/profile_dialogs.py:726
+#: src/ui/preferences/exclusions_page.py:130 src/ui/profile_dialogs.py:729
 msgid "Add"
 msgstr ""
 
@@ -3585,6 +3725,63 @@ msgid ""
 "enabled and the application runs."
 msgstr ""
 
+#: src/ui/preferences/debug_page.py:606
+msgid "Logs exported successfully"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:617
+msgid "Export Failed"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:618
+msgid "Failed to export log files. Check file permissions."
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:633
+msgid "ZIP Archives"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:636
+msgid "All Files"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:653
+msgid "No Logs to Clear"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:653
+msgid "There are no log files to delete."
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:697
+msgid "Delete all log files?"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:698
+#, python-brace-format
+msgid "This will permanently delete {count} log file(s) totaling {size}."
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:701 src/ui/profile_dialogs.py:823
+msgid "This action cannot be undone."
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:716
+msgid "Delete Logs"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:740
+msgid "Logs cleared successfully"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:743
+msgid "Clear Failed"
+msgstr ""
+
+#: src/ui/preferences/debug_page.py:744
+msgid "Some log files could not be deleted. They may be in use or protected."
+msgstr ""
+
 #: src/ui/preferences/device_scan_page.py:88 src/ui/preferences/window.py:51
 msgid "Device Scan"
 msgstr ""
@@ -3687,7 +3884,7 @@ msgid "Python bytecode cache"
 msgstr ""
 
 #: src/ui/preferences/exclusions_page.py:99 src/ui/preferences/window.py:47
-#: src/ui/profile_dialogs.py:234 src/ui/profile_dialogs.py:597
+#: src/ui/profile_dialogs.py:236 src/ui/profile_dialogs.py:599
 msgid "Exclusions"
 msgstr ""
 
@@ -4278,7 +4475,7 @@ msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:107
 #: src/ui/preferences/virustotal_page.py:129
-#: src/ui/virustotal_setup_dialog.py:169
+#: src/ui/virustotal_setup_dialog.py:170
 msgid "API Key"
 msgstr ""
 
@@ -4306,12 +4503,12 @@ msgid "Save Key"
 msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:177
-#: src/ui/virustotal_setup_dialog.py:143
+#: src/ui/virustotal_setup_dialog.py:144
 msgid "Get a free API key"
 msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:178
-#: src/ui/virustotal_setup_dialog.py:144
+#: src/ui/virustotal_setup_dialog.py:145
 msgid "Create an account at virustotal.com"
 msgstr ""
 
@@ -4356,17 +4553,17 @@ msgid "Files up to 650 MB can be scanned"
 msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:277
-#: src/ui/virustotal_setup_dialog.py:261
+#: src/ui/virustotal_setup_dialog.py:262
 msgid "Invalid API key format"
 msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:298
-#: src/ui/virustotal_setup_dialog.py:281
+#: src/ui/virustotal_setup_dialog.py:282
 msgid "API key saved"
 msgstr ""
 
 #: src/ui/preferences/virustotal_page.py:315
-#: src/ui/virustotal_setup_dialog.py:290
+#: src/ui/virustotal_setup_dialog.py:291
 #, python-brace-format
 msgid "Failed to save: {error}"
 msgstr ""
@@ -4393,8 +4590,8 @@ msgstr ""
 msgid "Failed to delete API key"
 msgstr ""
 
-#: src/ui/preferences/virustotal_page.py:385 src/ui/profile_dialogs.py:872
-#: src/ui/quarantine_view.py:725
+#: src/ui/preferences/virustotal_page.py:385 src/ui/profile_dialogs.py:878
+#: src/ui/quarantine_view.py:817 src/ui/quarantine_view.py:896
 msgid "Delete"
 msgstr ""
 
@@ -4414,366 +4611,414 @@ msgstr ""
 msgid "On-Access"
 msgstr ""
 
-#: src/ui/preferences/window.py:55 src/ui/profile_dialogs.py:127
+#: src/ui/preferences/window.py:55 src/ui/profile_dialogs.py:129
 msgid "Save"
 msgstr ""
 
-#: src/ui/preferences/window.py:145 src/ui/preferences/window.py:300
+#: src/ui/preferences/window.py:145 src/ui/preferences/window.py:301
 #: src/ui/window.py:631
 msgid "Preferences"
 msgstr ""
 
-#: src/ui/preferences/window.py:294 src/ui/window.py:517
+#: src/ui/preferences/window.py:295 src/ui/window.py:517
 msgid "Back to navigation"
 msgstr ""
 
-#: src/ui/preferences/window.py:524 src/ui/preferences/window.py:547
+#: src/ui/preferences/window.py:525 src/ui/preferences/window.py:548
 #, python-brace-format
 msgid "Preferences — {page}"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:101
+#: src/ui/profile_dialogs.py:102
 msgid "Edit Profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:103
+#: src/ui/profile_dialogs.py:104
 msgid "New Profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:161
+#: src/ui/profile_dialogs.py:163
 msgid "Profile Information"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:162
+#: src/ui/profile_dialogs.py:164
 msgid "Basic profile settings"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:173
+#: src/ui/profile_dialogs.py:175
 msgid "Description"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:190 src/ui/profile_dialogs.py:589
+#: src/ui/profile_dialogs.py:192 src/ui/profile_dialogs.py:591
 #: src/ui/scan/target_selector.py:78 src/ui/scan/target_selector.py:233
 #: src/ui/scan_view.py:933 src/ui/scan_view.py:1218
 msgid "Scan Targets"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:191
+#: src/ui/profile_dialogs.py:193
 msgid "Directories and files to scan"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:199
+#: src/ui/profile_dialogs.py:201
 msgid "Add folder"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:206
+#: src/ui/profile_dialogs.py:208
 msgid "Add file"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:220 src/ui/scan_view.py:974
+#: src/ui/profile_dialogs.py:222 src/ui/scan_view.py:974
 msgid "No targets added"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:222
+#: src/ui/profile_dialogs.py:224
 msgid "Click the folder or file button to add scan targets"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:235
+#: src/ui/profile_dialogs.py:237
 msgid "Paths and patterns to skip during scan"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:243
+#: src/ui/profile_dialogs.py:245
 msgid "Add exclusion path"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:250
+#: src/ui/profile_dialogs.py:252
 msgid "Add exclusion pattern"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:264
+#: src/ui/profile_dialogs.py:266
 msgid "No exclusions added"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:266
+#: src/ui/profile_dialogs.py:268
 msgid "Add paths or patterns to exclude from scanning"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:289
+#: src/ui/profile_dialogs.py:291
 msgid "Default profiles cannot be renamed"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:307 src/ui/profile_dialogs.py:610
+#: src/ui/profile_dialogs.py:309 src/ui/profile_dialogs.py:612
 msgid "Profile name is required"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:311
+#: src/ui/profile_dialogs.py:313
 #, python-brace-format
 msgid "Name must be {max_length} characters or less"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:374 src/ui/scan/target_selector.py:159
+#: src/ui/profile_dialogs.py:376 src/ui/scan/target_selector.py:159
 msgid "Select Folders"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:374
+#: src/ui/profile_dialogs.py:376
 msgid "Select Folder"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:376 src/ui/scan/target_selector.py:159
+#: src/ui/profile_dialogs.py:378 src/ui/scan/target_selector.py:159
 msgid "Select Files"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:376
+#: src/ui/profile_dialogs.py:378
 msgid "Select File"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:478
+#: src/ui/profile_dialogs.py:480
 msgid "Path"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:498 src/ui/profile_dialogs.py:748
+#: src/ui/profile_dialogs.py:500 src/ui/profile_dialogs.py:753
 msgid "Pattern"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:529 src/ui/scan_view.py:1009
+#: src/ui/profile_dialogs.py:531 src/ui/scan_view.py:1009
 msgid "Remove"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:587 src/ui/scan/target_selector.py:239
+#: src/ui/profile_dialogs.py:589 src/ui/scan/target_selector.py:239
 #: src/ui/scan_view.py:1224
 #, python-brace-format
 msgid "Scan Targets ({count})"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:595
+#: src/ui/profile_dialogs.py:597
 #, python-brace-format
 msgid "Exclusions ({count})"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:703
+#: src/ui/profile_dialogs.py:705
 msgid "Add Exclusion Pattern"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:744
+#: src/ui/profile_dialogs.py:749
 msgid "Enter a glob pattern to exclude (e.g., *.tmp, .git/*, cache/*)"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:812
+#: src/ui/profile_dialogs.py:817
 msgid "Delete Profile?"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:814
+#: src/ui/profile_dialogs.py:819
 #, python-brace-format
 msgid "Are you sure you want to delete the profile \"{profile_name}\"?"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:818
-msgid "This action cannot be undone."
-msgstr ""
-
-#: src/ui/profile_dialogs.py:931
+#: src/ui/profile_dialogs.py:937
 msgid "Restore Default Profiles?"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:934
+#: src/ui/profile_dialogs.py:940
 msgid ""
 "This will reset Quick Scan, Full Scan, and Home Folder profiles to their "
 "original settings. Any changes you made to these profiles will be lost."
 msgstr ""
 
-#: src/ui/profile_dialogs.py:939
+#: src/ui/profile_dialogs.py:945
 msgid "Your custom profiles will not be affected."
 msgstr ""
 
-#: src/ui/profile_dialogs.py:993 src/ui/quarantine_view.py:718
+#: src/ui/profile_dialogs.py:1000 src/ui/quarantine_view.py:810
 msgid "Restore"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1063
+#: src/ui/profile_dialogs.py:1070
 msgid "Manage Profiles"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1081
+#: src/ui/profile_dialogs.py:1089
 msgid "Restore default profiles"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1088
+#: src/ui/profile_dialogs.py:1096
 msgid "Import profile from file"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1095
+#: src/ui/profile_dialogs.py:1103
 msgid "Create new profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1113
+#: src/ui/profile_dialogs.py:1121
 msgid "Scan Profiles"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1114
+#: src/ui/profile_dialogs.py:1122
 msgid "Select a profile to edit or use for scanning"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1123
+#: src/ui/profile_dialogs.py:1131
 msgid "No profiles available"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1124
+#: src/ui/profile_dialogs.py:1132
 msgid "Click the + button to create a new profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1179
+#: src/ui/profile_dialogs.py:1193
 #, python-brace-format
 msgid "{count} target"
 msgid_plural "{count} targets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/profile_dialogs.py:1185
+#: src/ui/profile_dialogs.py:1199
 msgid "Default profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1203
+#: src/ui/profile_dialogs.py:1217
 msgid "Use this profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1212
+#: src/ui/profile_dialogs.py:1226
 msgid "Edit profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1220
+#: src/ui/profile_dialogs.py:1234
 msgid "Delete profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1224
+#: src/ui/profile_dialogs.py:1238
 msgid "Cannot delete default profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1235
+#: src/ui/profile_dialogs.py:1249
 msgid "Export profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1348
+#: src/ui/profile_dialogs.py:1362
 msgid "Export Profile"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:1399
+#: src/ui/profile_dialogs.py:1382
+#, python-brace-format
+msgid "Failed to export profile: {error}"
+msgstr ""
+
+#: src/ui/profile_dialogs.py:1384
+msgid "Profile exported"
+msgstr ""
+
+#: src/ui/profile_dialogs.py:1416
 msgid "Import Profile"
 msgstr ""
 
-#: src/ui/quarantine_view.py:157
-msgid "Quarantine Storage"
+#: src/ui/profile_dialogs.py:1433
+#, python-brace-format
+msgid "Failed to import profile: {error}"
 msgstr ""
 
-#: src/ui/quarantine_view.py:158
-msgid "Secure storage for isolated threats"
+#: src/ui/profile_dialogs.py:1435
+msgid "Profile imported"
 msgstr ""
 
-#: src/ui/quarantine_view.py:162
-msgid "Total Size"
-msgstr ""
-
-#: src/ui/quarantine_view.py:163
-msgid "Calculating..."
-msgstr ""
-
-#: src/ui/quarantine_view.py:168
-msgid "0 items"
-msgstr ""
-
-#: src/ui/quarantine_view.py:180
-msgid "Quarantined Files"
-msgstr ""
-
-#: src/ui/quarantine_view.py:181
-msgid "Detected threats isolated from your system"
-msgstr ""
-
-#: src/ui/quarantine_view.py:192 src/ui/quarantine_view.py:195
-msgid "Search by threat name or path..."
-msgstr ""
-
-#: src/ui/quarantine_view.py:214
-msgid "Refresh quarantine list"
-msgstr ""
-
-#: src/ui/quarantine_view.py:222
-msgid "Clear Old Items"
-msgstr ""
-
-#: src/ui/quarantine_view.py:223
-msgid "Remove quarantined files older than 30 days"
+#: src/ui/quarantine_view.py:240 src/ui/scan_view.py:2384
+#: src/ui/update_view.py:173
+msgid "Dismiss"
 msgstr ""
 
 #: src/ui/quarantine_view.py:254
-msgid "No Quarantined Files"
+msgid "Quarantine Storage"
 msgstr ""
 
 #: src/ui/quarantine_view.py:255
+msgid "Secure storage for isolated threats"
+msgstr ""
+
+#: src/ui/quarantine_view.py:259
+msgid "Total Size"
+msgstr ""
+
+#: src/ui/quarantine_view.py:260
+msgid "Calculating..."
+msgstr ""
+
+#: src/ui/quarantine_view.py:265
+msgid "0 items"
+msgstr ""
+
+#: src/ui/quarantine_view.py:277
+msgid "Quarantined Files"
+msgstr ""
+
+#: src/ui/quarantine_view.py:278
+msgid "Detected threats isolated from your system"
+msgstr ""
+
+#: src/ui/quarantine_view.py:288
+msgid "Search by threat name or path..."
+msgstr ""
+
+#: src/ui/quarantine_view.py:306
+msgid "Refresh quarantine list"
+msgstr ""
+
+#: src/ui/quarantine_view.py:314
+msgid "Clear Old Items"
+msgstr ""
+
+#: src/ui/quarantine_view.py:315
+msgid "Remove quarantined files older than 30 days"
+msgstr ""
+
+#: src/ui/quarantine_view.py:346
+msgid "No Quarantined Files"
+msgstr ""
+
+#: src/ui/quarantine_view.py:347
 msgid "Detected threats will be isolated here for review"
 msgstr ""
 
-#: src/ui/quarantine_view.py:267
+#: src/ui/quarantine_view.py:359
 msgid "No matching entries"
 msgstr ""
 
-#: src/ui/quarantine_view.py:268
+#: src/ui/quarantine_view.py:360
 msgid "Try a different search term"
 msgstr ""
 
-#: src/ui/quarantine_view.py:282
+#: src/ui/quarantine_view.py:374
 msgid "Loading quarantine entries..."
 msgstr ""
 
-#: src/ui/quarantine_view.py:554
+#: src/ui/quarantine_view.py:443 src/ui/quarantine_view.py:630
+msgid "filtered entries"
+msgstr ""
+
+#: src/ui/quarantine_view.py:646
 #, python-brace-format
 msgid "Removed {count} old quarantine entry"
 msgid_plural "Removed {count} old quarantine entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/quarantine_view.py:564
+#: src/ui/quarantine_view.py:656
 msgid "No old entries found to remove"
 msgstr ""
 
-#: src/ui/quarantine_view.py:618
+#: src/ui/quarantine_view.py:710
 #, python-brace-format
 msgid "{filtered} of {total} items"
 msgstr ""
 
-#: src/ui/quarantine_view.py:623
+#: src/ui/quarantine_view.py:715
 #, python-brace-format
 msgid "{count} item"
 msgid_plural "{count} items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/quarantine_view.py:666
+#: src/ui/quarantine_view.py:758 src/ui/quarantine_view.py:843
+#: src/ui/quarantine_view.py:895
 msgid "Unknown Threat"
 msgstr ""
 
-#: src/ui/quarantine_view.py:697
+#: src/ui/quarantine_view.py:789
 #, python-brace-format
 msgid "Quarantined: {date}"
 msgstr ""
 
-#: src/ui/quarantine_view.py:704
+#: src/ui/quarantine_view.py:796
 #, python-brace-format
 msgid "Size: {size}"
 msgstr ""
 
-#: src/ui/quarantine_view.py:757
+#: src/ui/quarantine_view.py:840
+msgid "Restore Quarantined File?"
+msgstr ""
+
+#: src/ui/quarantine_view.py:842
+#, python-brace-format
+msgid "This file was detected as \"{threat}\". It will be restored to {path}."
+msgstr ""
+
+#: src/ui/quarantine_view.py:844
+msgid "Restore Anyway"
+msgstr ""
+
+#: src/ui/quarantine_view.py:869
 msgid "File restored successfully"
 msgstr ""
 
-#: src/ui/quarantine_view.py:762
+#: src/ui/quarantine_view.py:874
 msgid "Failed to restore file"
 msgstr ""
 
-#: src/ui/quarantine_view.py:788
+#: src/ui/quarantine_view.py:891
+msgid "Permanently Delete File?"
+msgstr ""
+
+#: src/ui/quarantine_view.py:893
+#, python-brace-format
+msgid ""
+"The quarantined file from {path} (\"{threat}\") will be permanently deleted. "
+"This action cannot be undone."
+msgstr ""
+
+#: src/ui/quarantine_view.py:921
 msgid "File deleted successfully"
 msgstr ""
 
-#: src/ui/quarantine_view.py:793
+#: src/ui/quarantine_view.py:926
 msgid "Failed to delete file"
 msgstr ""
 
@@ -4794,71 +5039,71 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:47 src/ui/scan_view.py:1286
+#: src/ui/scan/scan_progress_widget.py:48 src/ui/scan_view.py:1286
 msgid "Scan Progress"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:61 src/ui/scan/scan_view.py:284
+#: src/ui/scan/scan_progress_widget.py:62 src/ui/scan/scan_view.py:284
 #: src/ui/scan_view.py:1300
 msgid "Scanning..."
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:71 src/ui/scan_view.py:1310
+#: src/ui/scan/scan_progress_widget.py:72 src/ui/scan_view.py:1310
 msgid "Currently scanning"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:72
-#: src/ui/scan/scan_progress_widget.py:117 src/ui/scan_view.py:1311
+#: src/ui/scan/scan_progress_widget.py:73
+#: src/ui/scan/scan_progress_widget.py:118 src/ui/scan_view.py:1311
 #: src/ui/scan_view.py:1947
 msgid "Waiting for scan data..."
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:82
-#: src/ui/scan/scan_progress_widget.py:120 src/ui/scan_view.py:1322
+#: src/ui/scan/scan_progress_widget.py:83
+#: src/ui/scan/scan_progress_widget.py:121 src/ui/scan_view.py:1322
 #: src/ui/scan_view.py:1952
 msgid "Scanned 0 files"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:92 src/ui/scan_results_dialog.py:202
+#: src/ui/scan/scan_progress_widget.py:93 src/ui/scan_results_dialog.py:203
 #: src/ui/scan_view.py:1332 src/ui/statistics_view.py:293
 msgid "Threats Detected"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:156
+#: src/ui/scan/scan_progress_widget.py:157
 #, python-brace-format
 msgid "Target {current} of {total} \\u2014 {pct}%"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:161
+#: src/ui/scan/scan_progress_widget.py:162
 #, python-brace-format
 msgid "Scanning... {pct}%"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:172
-#: src/ui/scan/scan_progress_widget.py:192 src/ui/scan_view.py:1544
+#: src/ui/scan/scan_progress_widget.py:173
+#: src/ui/scan/scan_progress_widget.py:193 src/ui/scan_view.py:1544
 #: src/ui/scan_view.py:1564
 #, python-brace-format
 msgid "Scanned {scanned} / {total} files"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:179
-#: src/ui/scan/scan_progress_widget.py:200 src/ui/scan_view.py:1527
+#: src/ui/scan/scan_progress_widget.py:180
+#: src/ui/scan/scan_progress_widget.py:201 src/ui/scan_view.py:1527
 #: src/ui/scan_view.py:1551 src/ui/scan_view.py:1572
 #, python-brace-format
 msgid "Scanned {scanned} files"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:184 src/ui/scan_view.py:1533
+#: src/ui/scan/scan_progress_widget.py:185 src/ui/scan_view.py:1533
 #: src/ui/scan_view.py:1556
 #, python-brace-format
 msgid "Target {current} of {total} ({cumulative} total)"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:210 src/ui/scan_view.py:1582
+#: src/ui/scan/scan_progress_widget.py:211 src/ui/scan_view.py:1582
 msgid "Unknown threat"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:233 src/ui/scan_view.py:1610
+#: src/ui/scan/scan_progress_widget.py:234 src/ui/scan_view.py:1610
 #, python-brace-format
 msgid "Threats Detected ({n})"
 msgid_plural "Threats Detected ({n})"
@@ -4956,29 +5201,29 @@ msgstr ""
 msgid "Scan Target (1)"
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:65
+#: src/ui/scan_in_progress_dialog.py:66
 msgid "Scan in Progress"
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:101
+#: src/ui/scan_in_progress_dialog.py:103
 msgid "<b><big>Scan in Progress</big></b>"
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:111
+#: src/ui/scan_in_progress_dialog.py:113
 msgid ""
 "A virus scan is currently running. If you close now, the scan will be "
 "cancelled and any partial results will be lost."
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:122
+#: src/ui/scan_in_progress_dialog.py:124
 msgid "Do you want to cancel the scan and close?"
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:134
+#: src/ui/scan_in_progress_dialog.py:136
 msgid "Keep Scanning"
 msgstr ""
 
-#: src/ui/scan_in_progress_dialog.py:139
+#: src/ui/scan_in_progress_dialog.py:141
 msgid "Cancel Scan and Close"
 msgstr ""
 
@@ -4986,179 +5231,179 @@ msgstr ""
 msgid "Scan Results"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:122
+#: src/ui/scan_results_dialog.py:123
 msgid "Export results"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:133 src/ui/scan_results_dialog.py:616
+#: src/ui/scan_results_dialog.py:134 src/ui/scan_results_dialog.py:621
 #, python-brace-format
 msgid "Quarantine {n} Threat"
 msgid_plural "Quarantine All ({n})"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:177 src/ui/sidebar.py:32
+#: src/ui/scan_results_dialog.py:178 src/ui/sidebar.py:32
 msgid "Statistics"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:188
+#: src/ui/scan_results_dialog.py:189
 #, python-brace-format
 msgid "No threats found ({count} file(s) not accessible)"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:198 src/ui/scan_results_dialog.py:210
+#: src/ui/scan_results_dialog.py:199 src/ui/scan_results_dialog.py:211
 #, python-brace-format
 msgid "{n} threat"
 msgid_plural "{n} threats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:203
+#: src/ui/scan_results_dialog.py:204
 #, python-brace-format
 msgid "{threat_text} found"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:215
+#: src/ui/scan_results_dialog.py:216
 #, python-brace-format
 msgid "Partial results - {threat_text} found"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:218
+#: src/ui/scan_results_dialog.py:219
 msgid "Partial results shown"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:240
+#: src/ui/scan_results_dialog.py:241
 msgid "Files scanned:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:243
+#: src/ui/scan_results_dialog.py:244
 msgid "Directories:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:248
+#: src/ui/scan_results_dialog.py:249
 msgid "Threats found:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:253
+#: src/ui/scan_results_dialog.py:254
 msgid "Not accessible:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:258
+#: src/ui/scan_results_dialog.py:259
 msgid "Error:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:288
+#: src/ui/scan_results_dialog.py:289
 msgid "Files Not Accessible"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:292
+#: src/ui/scan_results_dialog.py:293
 msgid "Permission Denied"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:296
+#: src/ui/scan_results_dialog.py:297
 #, python-brace-format
 msgid "{n} file could not be scanned"
 msgid_plural "{n} files could not be scanned"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:324
+#: src/ui/scan_results_dialog.py:325
 #, python-brace-format
 msgid "... and {count} more"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:346
+#: src/ui/scan_results_dialog.py:347
 #, python-brace-format
 msgid ""
 "<b>Large result set:</b> Found {count} threats. Displaying first {limit}."
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:395 src/ui/virustotal_results_dialog.py:338
+#: src/ui/scan_results_dialog.py:400 src/ui/virustotal_results_dialog.py:343
 #, python-brace-format
 msgid "Show {count} more"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:458 src/ui/sidebar.py:31
+#: src/ui/scan_results_dialog.py:463 src/ui/sidebar.py:31
 msgid "Quarantine"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:466
+#: src/ui/scan_results_dialog.py:471
 msgid "Exclude"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:469
+#: src/ui/scan_results_dialog.py:474
 msgid "Add file path to exclusion list"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:475
+#: src/ui/scan_results_dialog.py:480
 msgid "Copy Path"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:492
+#: src/ui/scan_results_dialog.py:497
 msgid "Quarantined"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:502
+#: src/ui/scan_results_dialog.py:507
 #, python-brace-format
 msgid "Quarantined: {name}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:505
+#: src/ui/scan_results_dialog.py:510
 #, python-brace-format
 msgid "Failed: {error}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:511
+#: src/ui/scan_results_dialog.py:516
 msgid "Cannot access settings"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:522 src/ui/scan_results_dialog.py:537
+#: src/ui/scan_results_dialog.py:527 src/ui/scan_results_dialog.py:542
 msgid "Excluded"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:525
+#: src/ui/scan_results_dialog.py:530
 msgid "Path already in exclusion list"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:542
+#: src/ui/scan_results_dialog.py:547
 #, python-brace-format
 msgid "Added to exclusions: {name}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:548
+#: src/ui/scan_results_dialog.py:553
 #, python-brace-format
 msgid "Copied: {path}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:556
+#: src/ui/scan_results_dialog.py:561
 msgid "Quarantining..."
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:591
+#: src/ui/scan_results_dialog.py:596
 #, python-brace-format
 msgid "Quarantined {n} threat"
 msgid_plural "Quarantined {n} threats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:598
+#: src/ui/scan_results_dialog.py:603
 #, python-brace-format
 msgid "Quarantined {success}, failed {failed}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:629
+#: src/ui/scan_results_dialog.py:634
 msgid "No results to export"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:638
+#: src/ui/scan_results_dialog.py:643
 msgid "Results copied to clipboard"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:639 src/ui/virustotal_results_dialog.py:452
+#: src/ui/scan_results_dialog.py:644 src/ui/virustotal_results_dialog.py:457
 msgid "Failed to copy results"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:647
+#: src/ui/scan_results_dialog.py:652
 msgid "Export Scan Results"
 msgstr ""
 
@@ -5305,10 +5550,6 @@ msgstr ""
 
 #: src/ui/scan_view.py:2383
 msgid "Ready to scan"
-msgstr ""
-
-#: src/ui/scan_view.py:2384 src/ui/update_view.py:173
-msgid "Dismiss"
 msgstr ""
 
 #: src/ui/sidebar.py:27
@@ -5638,7 +5879,7 @@ msgstr ""
 msgid "Click 'Update Database' to download the latest virus signatures"
 msgstr ""
 
-#: src/ui/update_view.py:120 src/ui/update_view.py:532
+#: src/ui/update_view.py:120 src/ui/update_view.py:536
 msgid "Update Database"
 msgstr ""
 
@@ -5680,20 +5921,20 @@ msgstr ""
 msgid "Checking service..."
 msgstr ""
 
-#: src/ui/update_view.py:264 src/ui/update_view.py:372
+#: src/ui/update_view.py:264 src/ui/update_view.py:376
 #, python-brace-format
 msgid "freshclam: {version}"
 msgstr ""
 
-#: src/ui/update_view.py:279 src/ui/update_view.py:384
+#: src/ui/update_view.py:279 src/ui/update_view.py:388
 msgid "freshclam not found"
 msgstr ""
 
-#: src/ui/update_view.py:284 src/ui/update_view.py:389
+#: src/ui/update_view.py:284 src/ui/update_view.py:393
 msgid "freshclam not installed"
 msgstr ""
 
-#: src/ui/update_view.py:288 src/ui/update_view.py:426
+#: src/ui/update_view.py:288 src/ui/update_view.py:430
 msgid "Service: N/A"
 msgstr ""
 
@@ -5701,138 +5942,138 @@ msgstr ""
 msgid "Error checking freshclam status"
 msgstr ""
 
-#: src/ui/update_view.py:417
+#: src/ui/update_view.py:421
 msgid "Service: Active"
 msgstr ""
 
-#: src/ui/update_view.py:423
+#: src/ui/update_view.py:427
 msgid "Service: Stopped"
 msgstr ""
 
-#: src/ui/update_view.py:429
+#: src/ui/update_view.py:433
 msgid "Service: Manual Mode"
 msgstr ""
 
-#: src/ui/update_view.py:488
+#: src/ui/update_view.py:492
 msgid "Force updating virus database..."
 msgstr ""
 
-#: src/ui/update_view.py:491
+#: src/ui/update_view.py:495
 msgid ""
 "Backing up local databases, then deleting them to force fresh downloads from "
 "mirrors."
 msgstr ""
 
-#: src/ui/update_view.py:494
+#: src/ui/update_view.py:498
 msgid "Previous databases will be restored if the update fails."
 msgstr ""
 
-#: src/ui/update_view.py:496 src/ui/update_view.py:502
+#: src/ui/update_view.py:500 src/ui/update_view.py:506
 msgid "Please wait, this may take a few minutes."
 msgstr ""
 
-#: src/ui/update_view.py:500
+#: src/ui/update_view.py:504
 msgid "Updating virus database..."
 msgstr ""
 
-#: src/ui/update_view.py:522
+#: src/ui/update_view.py:526
 msgid "Updating..."
 msgstr ""
 
-#: src/ui/update_view.py:586
+#: src/ui/update_view.py:590
 msgid "Update signal sent to freshclam service"
 msgstr ""
 
-#: src/ui/update_view.py:590
+#: src/ui/update_view.py:594
 #, python-brace-format
 msgid "Database updated successfully ({count} database updated)"
 msgid_plural "Database updated successfully ({count} databases updated)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/update_view.py:597
+#: src/ui/update_view.py:601
 msgid "Database is already up to date"
 msgstr ""
 
-#: src/ui/update_view.py:600
+#: src/ui/update_view.py:604
 msgid "Update cancelled"
 msgstr ""
 
-#: src/ui/update_view.py:603
+#: src/ui/update_view.py:607
 msgid "Update error occurred"
 msgstr ""
 
-#: src/ui/update_view.py:617
+#: src/ui/update_view.py:621
 msgid "UPDATE SIGNAL SENT TO FRESHCLAM SERVICE"
 msgstr ""
 
-#: src/ui/update_view.py:619
+#: src/ui/update_view.py:623
 msgid "UPDATE COMPLETE - DATABASE UPDATED"
 msgstr ""
 
-#: src/ui/update_view.py:621
+#: src/ui/update_view.py:625
 msgid "UPDATE COMPLETE - ALREADY UP TO DATE"
 msgstr ""
 
-#: src/ui/update_view.py:623
+#: src/ui/update_view.py:627
 msgid "UPDATE CANCELLED"
 msgstr ""
 
-#: src/ui/update_view.py:625
+#: src/ui/update_view.py:629
 msgid "UPDATE PARTIALLY COMPLETE"
 msgstr ""
 
-#: src/ui/update_view.py:627
+#: src/ui/update_view.py:631
 msgid "UPDATE RATE LIMITED"
 msgstr ""
 
-#: src/ui/update_view.py:629
+#: src/ui/update_view.py:633
 msgid "UPDATE ERROR"
 msgstr ""
 
-#: src/ui/update_view.py:636
+#: src/ui/update_view.py:640
 #, python-brace-format
 msgid "  Status: {status}"
 msgstr ""
 
-#: src/ui/update_view.py:637
+#: src/ui/update_view.py:641
 #, python-brace-format
 msgid "  Method: {method}"
 msgstr ""
 
-#: src/ui/update_view.py:639
+#: src/ui/update_view.py:643
 #, python-brace-format
 msgid "  Databases updated: {count}"
 msgstr ""
 
-#: src/ui/update_view.py:642
+#: src/ui/update_view.py:646
 #, python-brace-format
 msgid "  Updated databases: {databases}"
 msgstr ""
 
-#: src/ui/update_view.py:648
+#: src/ui/update_view.py:652
 #, python-brace-format
 msgid "  Already current: {databases}"
 msgstr ""
 
-#: src/ui/update_view.py:665
+#: src/ui/update_view.py:669
 #, python-brace-format
 msgid "  Rate limited: {databases}"
 msgstr ""
 
-#: src/ui/update_view.py:671
+#: src/ui/update_view.py:675
 msgid "Note: The freshclam service is handling the update in the background."
 msgstr ""
 
-#: src/ui/update_view.py:672
+#: src/ui/update_view.py:676
 msgid "Check service logs for detailed progress:"
 msgstr ""
 
-#: src/ui/update_view.py:684
+#: src/ui/update_view.py:688
 msgid "freshclam Output:"
 msgstr ""
 
-#: src/ui/update_view.py:690
+#: src/ui/update_view.py:694
 msgid "Error Output:"
 msgstr ""
 
@@ -5844,112 +6085,112 @@ msgstr ""
 msgid "VirusTotal Results"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:109
+#: src/ui/virustotal_results_dialog.py:110
 msgid "Export results to JSON"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:117
+#: src/ui/virustotal_results_dialog.py:118
 msgid "View on VirusTotal"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:156
+#: src/ui/virustotal_results_dialog.py:157
 msgid "Scan Summary"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:163
+#: src/ui/virustotal_results_dialog.py:164
 msgid "No threats detected"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:164
+#: src/ui/virustotal_results_dialog.py:165
 msgid "File appears to be safe"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:170
+#: src/ui/virustotal_results_dialog.py:171
 #, python-brace-format
 msgid "{count} engines detected threats"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:172
+#: src/ui/virustotal_results_dialog.py:173
 #, python-brace-format
 msgid "Detection ratio: {ratio}"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:176
+#: src/ui/virustotal_results_dialog.py:177
 msgid "File not in database"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:177
+#: src/ui/virustotal_results_dialog.py:178
 msgid "This file has not been scanned before"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:181
+#: src/ui/virustotal_results_dialog.py:182
 msgid "Analysis in progress"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:182
+#: src/ui/virustotal_results_dialog.py:183
 msgid "Check back later for results"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:186
+#: src/ui/virustotal_results_dialog.py:187
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:187
+#: src/ui/virustotal_results_dialog.py:188
 msgid "Too many requests"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:191
+#: src/ui/virustotal_results_dialog.py:192
 msgid "File too large"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:192
+#: src/ui/virustotal_results_dialog.py:193
 msgid "Maximum size is 650MB"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:207
+#: src/ui/virustotal_results_dialog.py:208
 msgid "Last scanned"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:231
+#: src/ui/virustotal_results_dialog.py:232
 msgid "File Information"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:245
+#: src/ui/virustotal_results_dialog.py:246
 msgid "Copy file path"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:269
+#: src/ui/virustotal_results_dialog.py:270
 msgid "Copy SHA256 hash"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:284
+#: src/ui/virustotal_results_dialog.py:285
 msgid "Detection Details"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:290
+#: src/ui/virustotal_results_dialog.py:291
 #, python-brace-format
 msgid "<small>Showing first {limit} of {total} detections</small>"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:408
-#: src/ui/virustotal_setup_dialog.py:242 src/ui/virustotal_setup_dialog.py:313
+#: src/ui/virustotal_results_dialog.py:413
+#: src/ui/virustotal_setup_dialog.py:243 src/ui/virustotal_setup_dialog.py:314
 msgid "Failed to open browser"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:413
+#: src/ui/virustotal_results_dialog.py:418
 msgid "File path copied"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:415
-#: src/ui/virustotal_results_dialog.py:422
+#: src/ui/virustotal_results_dialog.py:420
+#: src/ui/virustotal_results_dialog.py:427
 msgid "Failed to copy"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:420
+#: src/ui/virustotal_results_dialog.py:425
 msgid "SHA256 hash copied"
 msgstr ""
 
-#: src/ui/virustotal_results_dialog.py:450
+#: src/ui/virustotal_results_dialog.py:455
 msgid "Results copied to clipboard as JSON"
 msgstr ""
 
@@ -5957,41 +6198,41 @@ msgstr ""
 msgid "VirusTotal Setup"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:133
+#: src/ui/virustotal_setup_dialog.py:134
 msgid "VirusTotal API Key Required"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:136
+#: src/ui/virustotal_setup_dialog.py:137
 msgid ""
 "To scan files with VirusTotal, you need a free API key. You can get one by "
 "creating a free account on virustotal.com."
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:163
+#: src/ui/virustotal_setup_dialog.py:164
 msgid "Enter API Key"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:189
+#: src/ui/virustotal_setup_dialog.py:190
 msgid "Save & Scan"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:201
+#: src/ui/virustotal_setup_dialog.py:202
 msgid "Alternative Options"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:205
+#: src/ui/virustotal_setup_dialog.py:206
 msgid "Upload file manually"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:206
+#: src/ui/virustotal_setup_dialog.py:207
 msgid "Open VirusTotal website to upload files without API key"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:223
+#: src/ui/virustotal_setup_dialog.py:224
 msgid "Don't ask again when scanning without API key"
 msgstr ""
 
-#: src/ui/virustotal_setup_dialog.py:292
+#: src/ui/virustotal_setup_dialog.py:293
 msgid "Failed to save API key"
 msgstr ""
 

--- a/src/cli/help_cmd.py
+++ b/src/cli/help_cmd.py
@@ -61,6 +61,12 @@ _COMMANDS: dict[str, dict[str, str | list[str]]] = {
             "clamui history --type scan --json",
         ],
     },
+    "install-privileged-helper": {
+        "summary": N_("Install the polkit helper for saving system ClamAV configs"),
+        "examples": [
+            "sudo clamui install-privileged-helper",
+        ],
+    },
     "help": {
         "summary": N_("Show this help message"),
         "examples": [

--- a/src/cli/status_cmd.py
+++ b/src/cli/status_cmd.py
@@ -98,7 +98,10 @@ def run(args: argparse.Namespace) -> int:
     """
     settings = SettingsManager()
     log_manager = LogManager()
-    scanner = Scanner(log_manager=log_manager)
+    # Pass the settings manager so the reported backend honors the user's
+    # scan_backend / clamd_conf_path settings instead of always showing
+    # the "auto" default.
+    scanner = Scanner(log_manager=log_manager, settings_manager=settings)
 
     clamav_info = _collect_clamav_info(scanner, log_manager)
     quarantine_stats = _collect_quarantine_stats()

--- a/src/core/clamav_detection.py
+++ b/src/core/clamav_detection.py
@@ -29,6 +29,35 @@ _DATABASE_EXTENSIONS = {".cvd", ".cld", ".cud"}
 _DEFAULT_DATABASE_DIRS = ("/var/lib/clamav", "/usr/local/share/clamav")
 
 
+def systemd_unit_exists(unit_name: str) -> bool:
+    """
+    Check whether a systemd unit is actually known to systemd.
+
+    `systemctl is-active` prints "inactive" for units systemd has never
+    heard of, so callers probing multiple candidate unit names cannot use
+    its output alone to distinguish "installed but stopped" from
+    "not installed". LoadState is "loaded" only for real units.
+
+    Args:
+        unit_name: Full unit name (e.g. "clamav-freshclam.service")
+
+    Returns:
+        True if systemd reports the unit as loaded, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            wrap_host_command(["systemctl", "show", "-p", "LoadState", "--value", unit_name]),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=get_clean_env(),
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        logger.debug("systemctl show failed for %s", unit_name, exc_info=True)
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "loaded"
+
+
 def check_clamav_installed() -> tuple[bool, str | None]:
     """
     Check if ClamAV (clamscan) is installed and accessible.

--- a/src/core/log_manager.py
+++ b/src/core/log_manager.py
@@ -1952,7 +1952,14 @@ class LogManager:
                 if status_text == "active":
                     return (DaemonStatus.RUNNING, f"{service_name} is active")
                 if status_text in {"inactive", "failed", "activating", "deactivating"}:
-                    saw_installed_service = True
+                    # "inactive" alone doesn't prove the unit exists: systemd
+                    # prints it for units it has never heard of, which would
+                    # misreport a machine with no clamd at all as
+                    # "installed but not active". Confirm via LoadState.
+                    from .clamav_detection import systemd_unit_exists
+
+                    if systemd_unit_exists(service_name):
+                        saw_installed_service = True
             except (subprocess.SubprocessError, FileNotFoundError, OSError):
                 logger.debug("systemctl is-active failed for %s", service_name, exc_info=True)
 

--- a/src/core/quarantine/file_handler.py
+++ b/src/core/quarantine/file_handler.py
@@ -82,6 +82,20 @@ def _unlinkat(path: Path) -> None:
             os.close(parent_fd)
 
 
+def _write_all(fd: int, block: bytes) -> None:
+    """Write the whole block to fd, retrying on short writes.
+
+    os.write() may write fewer bytes than requested (e.g. when the disk
+    fills mid-write). Silently accepting a short write would produce a
+    truncated file whose recorded SHA-256 never verifies — after the source
+    is unlinked, the content would be unrecoverable.
+    """
+    view = memoryview(block)
+    while view:
+        written = os.write(fd, view)
+        view = view[written:]
+
+
 class SecureFileHandler:
     """
     Handler for secure file operations with permission management.
@@ -642,7 +656,7 @@ class SecureFileHandler:
                         if not block:
                             break
                         sha256_hash.update(block)
-                        os.write(dst_fd, block)
+                        _write_all(dst_fd, block)
                     os.fsync(dst_fd)
                     # fchmod via fd before close — no path-based TOCTOU window, and
                     # bypasses umask so permissions are applied exactly as specified.
@@ -907,7 +921,7 @@ class SecureFileHandler:
                         if not block:
                             break
                         sha256_hash.update(block)
-                        os.write(dst_fd, block)
+                        _write_all(dst_fd, block)
                     os.fsync(dst_fd)
                     # fchmod via fd — no path-based window, bypasses umask.
                     os.fchmod(dst_fd, masked_permissions)

--- a/src/core/scanner.py
+++ b/src/core/scanner.py
@@ -82,7 +82,13 @@ def glob_to_regex(pattern: str) -> str:
     # Add anchors to ensure full string match (prevents substring matching)
     if not regex.startswith("^"):
         regex = "^" + regex
-    if not regex.endswith("$"):
+    # A trailing "$" only counts as an anchor when it isn't escaped: a glob
+    # like "backup$" translates to r"backup\$", and skipping the anchor there
+    # would hand ClamAV an end-unanchored ERE that silently widens the
+    # exclusion to every path starting with "backup$".
+    body = regex[:-1] if regex.endswith("$") else None
+    has_unescaped_anchor = body is not None and (len(body) - len(body.rstrip("\\"))) % 2 == 0
+    if not has_unescaped_anchor:
         regex = regex + "$"
     return regex
 

--- a/src/core/scanner_base.py
+++ b/src/core/scanner_base.py
@@ -277,17 +277,21 @@ def stream_process_output(
                 remaining_stderr = "".join(remaining_stderr_chunks)
 
                 if remaining_stdout:
-                    # Process remaining data including incomplete line
+                    # Line callbacks get the buffered partial line rejoined with
+                    # the drained data; the accumulated buffer must only receive
+                    # the newly drained bytes — incomplete_line was already
+                    # appended as part of the chunk it arrived in, and appending
+                    # it again would corrupt the final output parsed for results.
                     data = incomplete_line + remaining_stdout
                     lines = data.split("\n")
                     for line in lines:
                         if line:  # Skip empty lines from split
                             on_line(line)
-                    stdout_total = _append(stdout_parts, stdout_total, data, "stdout")
+                    stdout_total = _append(stdout_parts, stdout_total, remaining_stdout, "stdout")
                 elif incomplete_line:
-                    # Process the final incomplete line
+                    # Flush the final incomplete line to the callback only; its
+                    # bytes are already in stdout_parts.
                     on_line(incomplete_line)
-                    stdout_total = _append(stdout_parts, stdout_total, incomplete_line, "stdout")
                 if remaining_stderr:
                     stderr_total = _append(stderr_parts, stderr_total, remaining_stderr, "stderr")
                 break

--- a/src/core/updater.py
+++ b/src/core/updater.py
@@ -28,6 +28,7 @@ from .utils import (
     check_freshclam_installed,
     get_clean_env,
     get_freshclam_path,
+    systemd_unit_exists,
     wrap_host_command,
 )
 
@@ -179,7 +180,8 @@ class FreshclamUpdater:
                     timeout=5,
                 )
 
-                if result.returncode == 0 and result.stdout.strip() == "active":
+                state = result.stdout.strip().lower()
+                if result.returncode == 0 and state == "active":
                     # Service is active, get the PID
                     try:
                         pid_result = subprocess.run(
@@ -198,13 +200,18 @@ class FreshclamUpdater:
                             return FreshclamServiceStatus.RUNNING, pid
                     except (subprocess.TimeoutExpired, OSError) as e:
                         logger.warning("Failed to get freshclam PID: %s", e)
-                        # Service is active but couldn't get PID
-                        return FreshclamServiceStatus.RUNNING, None
+                    # Service is active even if the PID lookup failed
+                    return FreshclamServiceStatus.RUNNING, None
 
-                elif result.returncode == 0 or "inactive" in result.stdout.strip().lower():
-                    # Service exists but is stopped
-                    logger.debug("Service %s exists but is not running", service_name)
-                    return FreshclamServiceStatus.STOPPED, None
+                elif state in ("inactive", "failed", "activating", "deactivating"):
+                    # systemd prints "inactive" even for units it has never
+                    # heard of, so confirm the unit actually exists before
+                    # concluding installed-but-stopped — otherwise a distro
+                    # using the other unit name (openSUSE's freshclam.service)
+                    # would short-circuit here and never be probed.
+                    if systemd_unit_exists(service_name):
+                        logger.debug("Service %s exists but is not running", service_name)
+                        return FreshclamServiceStatus.STOPPED, None
 
             except subprocess.TimeoutExpired:
                 logger.warning("Timeout checking service %s", service_name)

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -30,6 +30,7 @@ from .clamav_detection import (
     get_freshclam_path,
     resolve_clamd_conf_path,
     resolve_freshclam_conf_path,
+    systemd_unit_exists,
 )
 from .clipboard import copy_to_clipboard
 from .flatpak import (
@@ -89,6 +90,7 @@ __all__ = [
     "is_flatpak",
     "resolve_clamd_conf_path",
     "resolve_freshclam_conf_path",
+    "systemd_unit_exists",
     "validate_dropped_files",
     "validate_path",
     "which_host_command",

--- a/src/ui/close_behavior_dialog.py
+++ b/src/ui/close_behavior_dialog.py
@@ -13,6 +13,7 @@ from gi.repository import Adw, Gtk
 
 from ..core.i18n import _
 from .compat import create_toolbar_view
+from .utils import enable_escape_to_close
 
 
 class CloseBehaviorDialog(Adw.Window):
@@ -70,6 +71,7 @@ class CloseBehaviorDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         # Connect to close-request signal for when user dismisses without choosing

--- a/src/ui/compat.py
+++ b/src/ui/compat.py
@@ -559,3 +559,30 @@ def safe_set_subtitle_lines(row, value: int) -> None:
     """Call set_subtitle_lines if available (libadwaita 1.2+)."""
     if hasattr(row, "set_subtitle_lines"):
         row.set_subtitle_lines(value)
+
+
+def remove_all_children(listbox) -> None:
+    """Remove every row from a Gtk.ListBox.
+
+    Gtk.ListBox.remove_all() only exists on GTK 4.12+; iterate manually so
+    the code works on the GTK 4.6 baseline (Ubuntu 22.04).
+    """
+    if hasattr(listbox, "remove_all"):
+        listbox.remove_all()
+        return
+    while True:
+        child = listbox.get_first_child()
+        if child is None:
+            break
+        listbox.remove(child)
+
+
+def safe_set_placeholder_text(entry, text: str) -> None:
+    """Set placeholder text on a Gtk.SearchEntry if supported.
+
+    Gtk.SearchEntry gained the placeholder-text property (and its
+    set_placeholder_text accessor) in GTK 4.10; on older versions setting
+    the property raises TypeError, so skip it entirely.
+    """
+    if hasattr(entry, "set_placeholder_text"):
+        entry.set_placeholder_text(text)

--- a/src/ui/components_view.py
+++ b/src/ui/components_view.py
@@ -51,8 +51,9 @@ SETUP_GUIDES = {
         ],
         "notes": N_(
             "freshclam updates the virus database. Enable the service for automatic updates:"
-        )
-        + "\nsudo systemctl enable clamav-freshclam\nsudo systemctl start clamav-freshclam",
+        ),
+        # Shell commands appended verbatim after the translated notes
+        "notes_commands": "sudo systemctl enable clamav-freshclam\nsudo systemctl start clamav-freshclam",
     },
     "clamdscan": {
         "title": N_("clamdscan Installation"),
@@ -81,12 +82,15 @@ SETUP_GUIDES = {
                 "sudo pacman -S clamav\nsudo systemctl enable clamav-daemon\nsudo systemctl start clamav-daemon",
             ),
         ],
-        "notes": N_("clamd is the ClamAV daemon for faster scanning.")
-        + " "
-        + N_("Configuration file location is auto-detected in Preferences.")
-        + " "
-        + N_(
-            "On Fedora, ClamUI uses /etc/clamd.d/scan.conf. If the daemon is running but still unavailable, verify socket permissions and test with: clamdscan --config-file=/etc/clamd.d/scan.conf --ping 3"
+        # A tuple of sentences: each is translated separately at display
+        # time, then joined — concatenating N_() results at module level
+        # would produce msgids that never match the catalog.
+        "notes": (
+            N_("clamd is the ClamAV daemon for faster scanning."),
+            N_("Configuration file location is auto-detected in Preferences."),
+            N_(
+                "On Fedora, ClamUI uses /etc/clamd.d/scan.conf. If the daemon is running but still unavailable, verify socket permissions and test with: clamdscan --config-file=/etc/clamd.d/scan.conf --ping 3"
+            ),
         ),
     },
 }
@@ -287,8 +291,17 @@ class ComponentsView(Gtk.Box):
             command_row = self._create_command_row(distro, command)
             content_box.append(command_row)
 
-        # Add notes if present
+        # Add notes if present. "notes" is one N_()-marked string or a tuple
+        # of them; translate each at display time. Any "notes_commands" shell
+        # text is appended verbatim (never translated).
         notes = guide.get("notes", "")
+        if isinstance(notes, tuple):
+            notes = " ".join(_(part) for part in notes)
+        elif notes:
+            notes = _(notes)
+        notes_commands = guide.get("notes_commands", "")
+        if notes_commands:
+            notes = f"{notes}\n{notes_commands}" if notes else notes_commands
         if notes:
             notes_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
             notes_box.set_margin_top(6)

--- a/src/ui/database_missing_dialog.py
+++ b/src/ui/database_missing_dialog.py
@@ -16,7 +16,7 @@ from gi.repository import Adw, Gtk
 
 from ..core.i18n import _
 from .compat import create_toolbar_view
-from .utils import resolve_icon_name
+from .utils import enable_escape_to_close, resolve_icon_name
 
 
 class DatabaseMissingDialog(Adw.Window):
@@ -69,6 +69,7 @@ class DatabaseMissingDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         # Connect to close-request signal for when user dismisses without choosing

--- a/src/ui/file_export.py
+++ b/src/ui/file_export.py
@@ -186,8 +186,8 @@ class FileExportHelper:
             self._dialog_title,
             window,
             Gtk.FileChooserAction.SAVE,
-            "_Save",
-            "_Cancel",
+            _("_Save"),
+            _("_Cancel"),
         )
         dialog.set_current_name(default_name)
         dialog.add_filter(gtk_filter)

--- a/src/ui/file_manager_integration_dialog.py
+++ b/src/ui/file_manager_integration_dialog.py
@@ -325,9 +325,12 @@ class FileManagerIntegrationDialog(Adw.Window):
             # is_active + INSTALLED = no-op
             # not is_active + NOT_INSTALLED = no-op
 
-        # Show result summary
+        # Show result summary. On failure keep the dialog open — closing it
+        # immediately would destroy the toast before the user could see that
+        # anything failed (details are only in the log).
         self._show_result_toast(installed_count, removed_count, repaired_count, error_count)
-        self._save_preference_and_close()
+        if error_count == 0:
+            self._save_preference_and_close()
 
     def _show_result_toast(self, installed: int, removed: int, repaired: int, errors: int):
         """Show a summary toast of the apply results."""

--- a/src/ui/file_manager_integration_dialog.py
+++ b/src/ui/file_manager_integration_dialog.py
@@ -28,7 +28,7 @@ from ..core.file_manager_integration import (
 )
 from ..core.i18n import _
 from .compat import create_switch_row, create_toolbar_view
-from .utils import resolve_icon_name
+from .utils import enable_escape_to_close, resolve_icon_name
 
 if TYPE_CHECKING:
     from ..core.settings_manager import SettingsManager
@@ -88,6 +88,7 @@ class FileManagerIntegrationDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):

--- a/src/ui/fullscreen_dialog.py
+++ b/src/ui/fullscreen_dialog.py
@@ -11,6 +11,7 @@ from gi.repository import Adw, Gtk
 
 from ..core.i18n import N_, _
 from .compat import create_toolbar_view
+from .utils import enable_escape_to_close
 
 
 class FullscreenLogDialog(Adw.Window):
@@ -68,6 +69,7 @@ class FullscreenLogDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
 
         # Allow the dialog to be closed
         self.set_deletable(True)

--- a/src/ui/logs_view.py
+++ b/src/ui/logs_view.py
@@ -548,13 +548,16 @@ class LogsView(Gtk.Box):
         self._daemon_text.set_bottom_margin(12)
         self._daemon_text.add_css_class("monospace")
 
-        # Set placeholder text
-        buffer = self._daemon_text.get_buffer()
-        buffer.set_text(
+        # Set placeholder text. Keep a reference so the export handler can
+        # recognize it regardless of locale (string matching on the English
+        # text would fail on translated placeholders).
+        self._daemon_placeholder_text = (
             _("Daemon logs will appear here.")
             + "\n\n"
             + _("Click the play button to start live updates.")
         )
+        buffer = self._daemon_text.get_buffer()
+        buffer.set_text(self._daemon_placeholder_text)
 
         scrolled.set_child(self._daemon_text)
 
@@ -1111,7 +1114,7 @@ class LogsView(Gtk.Box):
         content = buffer.get_text(start, end, False)
 
         # Don't export placeholder text
-        if "will appear here" in content:
+        if not content or content == getattr(self, "_daemon_placeholder_text", None):
             return
 
         helper = FileExportHelper(

--- a/src/ui/logs_view.py
+++ b/src/ui/logs_view.py
@@ -15,7 +15,12 @@ from ..core.i18n import _
 from ..core.log_manager import DaemonStatus, LogEntry, LogManager
 from ..core.statistics_calculator import StatisticsCalculator
 from .clipboard_helper import ClipboardHelper
-from .compat import create_toolbar_view, safe_add_suffix, safe_add_titled_with_icon
+from .compat import (
+    create_toolbar_view,
+    remove_all_children,
+    safe_add_suffix,
+    safe_add_titled_with_icon,
+)
 from .file_export import CSV_FILTER, JSON_FILTER, TEXT_FILTER, FileExportHelper
 from .fullscreen_dialog import FullscreenLogDialog
 from .pagination import PaginatedListController
@@ -1219,7 +1224,8 @@ class LogsView(Gtk.Box):
 
                 # Clear existing rows and show loading placeholder in listbox
                 # This is done synchronously but is fast enough for typical row counts
-                self._logs_listbox.remove_all()
+                # (Gtk.ListBox.remove_all() requires GTK 4.12+)
+                remove_all_children(self._logs_listbox)
                 loading_row = self._create_loading_state()
                 self._logs_listbox.append(loading_row)
             else:

--- a/src/ui/logs_view.py
+++ b/src/ui/logs_view.py
@@ -11,7 +11,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib, GObject, Gtk
 
-from ..core.i18n import _
+from ..core.i18n import _, ngettext
 from ..core.log_manager import DaemonStatus, LogEntry, LogManager
 from ..core.statistics_calculator import StatisticsCalculator
 from .clipboard_helper import ClipboardHelper
@@ -611,7 +611,7 @@ class LogsView(Gtk.Box):
             self._all_log_entries = logs
 
             # Use pagination controller to display logs
-            self._pagination.set_entries(logs, entries_label="logs")
+            self._pagination.set_entries(logs, entries_label=_("logs"))
 
             # Handle empty logs - placeholder will be shown automatically
             # by GTK ListBox since we set it with set_placeholder()
@@ -664,12 +664,12 @@ class LogsView(Gtk.Box):
     def _add_load_more_button(self):
         """Add load more button (backward compatibility - delegates to pagination controller)."""
         if hasattr(self, "_pagination"):
-            self._pagination.add_load_more_button(entries_label="logs")
+            self._pagination.add_load_more_button(entries_label=_("logs"))
 
     def _on_load_more_logs_clicked(self, button):
         """Handle load more button click (backward compatibility - delegates to pagination controller)."""
         if hasattr(self, "_pagination"):
-            self._pagination.load_more(entries_label="logs")
+            self._pagination.load_more(entries_label=_("logs"))
 
     def _on_show_all_logs_clicked(self, button):
         """Handle show all button click (backward compatibility - delegates to pagination controller)."""
@@ -887,8 +887,8 @@ class LogsView(Gtk.Box):
         helper = ClipboardHelper(parent_widget=self)
         helper.copy_with_feedback(
             text=content,
-            success_message="Log details copied to clipboard",
-            error_message="Failed to copy to clipboard",
+            success_message=_("Log details copied to clipboard"),
+            error_message=_("Failed to copy to clipboard"),
             on_too_large=lambda: self._on_export_detail_text_clicked(button),
         )
 
@@ -904,7 +904,7 @@ class LogsView(Gtk.Box):
 
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export Log Details",
+            dialog_title=_("Export Log Details"),
             filename_prefix="clamui_log",
             file_filter=TEXT_FILTER,
             content_generator=self._get_detail_text_content,
@@ -923,7 +923,7 @@ class LogsView(Gtk.Box):
 
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export Log Details as CSV",
+            dialog_title=_("Export Log Details as CSV"),
             filename_prefix="clamui_log",
             file_filter=CSV_FILTER,
             content_generator=lambda: self._format_log_entry_as_csv(self._selected_log),
@@ -942,7 +942,7 @@ class LogsView(Gtk.Box):
 
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export Log Details as JSON",
+            dialog_title=_("Export Log Details as JSON"),
             filename_prefix="clamui_log",
             file_filter=JSON_FILTER,
             content_generator=lambda: self._format_log_entry_as_json(self._selected_log),
@@ -1098,7 +1098,7 @@ class LogsView(Gtk.Box):
         content = buffer.get_text(start, end, False)
 
         # Create and present the fullscreen dialog
-        dialog = FullscreenLogDialog(title="Daemon Logs", content=content)
+        dialog = FullscreenLogDialog(title=_("Daemon Logs"), content=content)
         dialog.set_transient_for(self.get_root())
         dialog.present()
 
@@ -1116,11 +1116,11 @@ class LogsView(Gtk.Box):
 
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export Daemon Logs",
+            dialog_title=_("Export Daemon Logs"),
             filename_prefix="clamd_logs",
             file_filter=TEXT_FILTER,
             content_generator=lambda: content,
-            success_message="Exported daemon logs",
+            success_message=_("Exported daemon logs"),
         )
         helper.show_save_dialog()
 
@@ -1137,11 +1137,13 @@ class LogsView(Gtk.Box):
         count = len(self._all_log_entries)
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export All Logs to CSV",
+            dialog_title=_("Export All Logs to CSV"),
             filename_prefix="clamui_logs",
             file_filter=CSV_FILTER,
             content_generator=self._format_all_logs_as_csv,
-            success_message=f"Exported {count} logs",
+            success_message=ngettext("Exported {n} log", "Exported {n} logs", count).format(
+                n=count
+            ),
         )
         helper.show_save_dialog()
 
@@ -1158,11 +1160,13 @@ class LogsView(Gtk.Box):
         count = len(self._all_log_entries)
         helper = FileExportHelper(
             parent_widget=self,
-            dialog_title="Export All Logs to JSON",
+            dialog_title=_("Export All Logs to JSON"),
             filename_prefix="clamui_logs",
             file_filter=JSON_FILTER,
             content_generator=self._format_all_logs_as_json,
-            success_message=f"Exported {count} logs",
+            success_message=ngettext("Exported {n} log", "Exported {n} logs", count).format(
+                n=count
+            ),
         )
         helper.show_save_dialog()
 
@@ -1355,7 +1359,7 @@ class LogsView(Gtk.Box):
             # Enable export button when logs are available
             self._export_daemon_button.set_sensitive(True)
         else:
-            buffer.set_text(f"Error loading daemon logs:\n\n{content}")
+            buffer.set_text(_("Error loading daemon logs:") + f"\n\n{content}")
             # Disable export button on error
             self._export_daemon_button.set_sensitive(False)
 

--- a/src/ui/logs_view.py
+++ b/src/ui/logs_view.py
@@ -24,7 +24,7 @@ from .compat import (
 from .file_export import CSV_FILTER, JSON_FILTER, TEXT_FILTER, FileExportHelper
 from .fullscreen_dialog import FullscreenLogDialog
 from .pagination import PaginatedListController
-from .utils import add_row_icon, resolve_icon_name
+from .utils import add_row_icon, enable_escape_to_close, resolve_icon_name
 from .view_helpers import EmptyStateConfig, create_empty_state, create_loading_row
 
 
@@ -63,6 +63,7 @@ class ClearLogsDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         self._setup_ui()

--- a/src/ui/pagination.py
+++ b/src/ui/pagination.py
@@ -150,7 +150,7 @@ class PaginatedListController:
                 # Skip entries that fail to render (corrupted data)
                 continue
 
-    def add_load_more_button(self, entries_label: str = "entries"):
+    def add_load_more_button(self, entries_label: str | None = None):
         """
         Add a 'Show More' and 'Show All' button row to the listbox.
 
@@ -165,6 +165,9 @@ class PaginatedListController:
             entries_label: Label for the items being paginated (e.g., "entries",
                           "logs", "filtered entries"). Used in progress text.
         """
+        if entries_label is None:
+            entries_label = _("entries")
+
         load_more_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         load_more_box.set_halign(Gtk.Align.CENTER)
         load_more_box.set_margin_top(12)
@@ -218,7 +221,7 @@ class PaginatedListController:
         self._load_more_row = load_more_row
         self._listbox.append(load_more_row)
 
-    def load_more(self, entries_label: str = "entries"):
+    def load_more(self, entries_label: str | None = None):
         """
         Load and display the next batch of entries.
 
@@ -286,7 +289,7 @@ class PaginatedListController:
             # Explicitly return False to remove callback after execution
             GLib.idle_add(lambda: (vadj.set_value(scroll_pos), False)[1])
 
-    def set_entries(self, entries: list, entries_label: str = "entries"):
+    def set_entries(self, entries: list, entries_label: str | None = None):
         """
         Set entries and display initial batch with pagination.
 

--- a/src/ui/preferences/database_page.py
+++ b/src/ui/preferences/database_page.py
@@ -793,7 +793,16 @@ class DatabasePage(PreferencesPageMixin):
         for key in ("Checks", "HTTPProxyPort"):
             populate_int_field(config, widgets_dict, key)
 
-        # Load existing DatabaseCustomURL entries
+        # Load existing DatabaseCustomURL entries. Clear rows from any prior
+        # populate first — reloading the config (e.g. after Detect/Browse)
+        # would otherwise duplicate every URL row and write duplicated
+        # DatabaseCustomURL lines on the next save.
+        group = widgets_dict.get("_custom_url_group")
+        for row, _url in widgets_dict.get("_custom_url_rows", []):
+            if group:
+                group.remove(row)
+        if "_custom_url_rows" in widgets_dict:
+            widgets_dict["_custom_url_rows"] = []
         if config.has_key("DatabaseCustomURL"):
             for url in config.get_values("DatabaseCustomURL"):
                 if url:  # Skip empty values
@@ -808,8 +817,14 @@ class DatabasePage(PreferencesPageMixin):
             widgets_dict: Dictionary containing widget references
 
         Returns:
-            Dictionary of configuration key-value pairs to save
+            Dictionary of configuration key-value pairs to save, or an empty
+            dict when the page was never created (no widgets to read).
+            Collecting from an empty widgets dict would report an empty
+            DatabaseCustomURL list and strip the user's custom URLs on save.
         """
+        if not widgets_dict:
+            return {}
+
         updates = {}
 
         # Collect DatabaseDirectory

--- a/src/ui/preferences/debug_page.py
+++ b/src/ui/preferences/debug_page.py
@@ -23,7 +23,7 @@ from ...core.flatpak import is_flatpak
 from ...core.i18n import N_, _, ngettext
 from ...core.logging_config import get_logging_config
 from ..compat import create_toolbar_view, save_path_dialog
-from ..utils import resolve_icon_name
+from ..utils import enable_escape_to_close, resolve_icon_name
 from .base import PreferencesPageMixin, styled_prefix_icon
 
 logger = logging.getLogger(__name__)
@@ -603,7 +603,7 @@ class DebugPage(PreferencesPageMixin):
 
         def on_export_success():
             """Called when export succeeds."""
-            self._show_toast("Logs exported successfully")
+            self._show_toast(_("Logs exported successfully"))
             self._update_log_size_display()
 
         def on_file_selected(file_path: str):
@@ -614,8 +614,8 @@ class DebugPage(PreferencesPageMixin):
             else:
                 GLib.idle_add(
                     self._show_simple_dialog,
-                    "Export Failed",
-                    "Failed to export log files. Check file permissions.",
+                    _("Export Failed"),
+                    _("Failed to export log files. Check file permissions."),
                 )
 
         # Use custom file chooser since we need ZIP export (not text content)
@@ -630,10 +630,10 @@ class DebugPage(PreferencesPageMixin):
             on_save_callback: Callback with file path when saved
         """
         zip_filter = Gtk.FileFilter()
-        zip_filter.set_name("ZIP Archives")
+        zip_filter.set_name(_("ZIP Archives"))
         zip_filter.add_pattern("*.zip")
         all_filter = Gtk.FileFilter()
-        all_filter.set_name("All Files")
+        all_filter.set_name(_("All Files"))
         all_filter.add_pattern("*")
 
         save_path_dialog(
@@ -650,7 +650,7 @@ class DebugPage(PreferencesPageMixin):
         log_files = logging_config.get_log_files()
 
         if not log_files:
-            self._show_simple_dialog("No Logs to Clear", "There are no log files to delete.")
+            self._show_simple_dialog(_("No Logs to Clear"), _("There are no log files to delete."))
             return
 
         # Show confirmation dialog
@@ -662,6 +662,7 @@ class DebugPage(PreferencesPageMixin):
         dialog.set_title(_("Clear Logs"))
         dialog.set_default_size(400, -1)
         dialog.set_modal(True)
+        enable_escape_to_close(dialog)
         dialog.set_deletable(True)
         dialog.set_transient_for(self._parent_window)
 
@@ -693,12 +694,12 @@ class DebugPage(PreferencesPageMixin):
         file_count = len(logging_config.get_log_files())
 
         label = Gtk.Label()
-        label.set_markup(
-            f"<b>Delete all log files?</b>\n\n"
-            f"This will permanently delete {file_count} log file(s) "
-            f"totaling {size_str}.\n\n"
-            f"This action cannot be undone."
+        heading = _("Delete all log files?")
+        body = _("This will permanently delete {count} log file(s) totaling {size}.").format(
+            count=file_count, size=size_str
         )
+        footer = _("This action cannot be undone.")
+        label.set_markup(f"<b>{heading}</b>\n\n{body}\n\n{footer}")
         label.set_wrap(True)
         label.set_justify(Gtk.Justification.CENTER)
         content_box.append(label)
@@ -708,11 +709,11 @@ class DebugPage(PreferencesPageMixin):
         button_box.set_halign(Gtk.Align.CENTER)
         button_box.set_margin_top(12)
 
-        cancel_button = Gtk.Button(label="Cancel")
+        cancel_button = Gtk.Button(label=_("Cancel"))
         cancel_button.connect("clicked", lambda _: dialog.close())
         button_box.append(cancel_button)
 
-        delete_button = Gtk.Button(label="Delete Logs")
+        delete_button = Gtk.Button(label=_("Delete Logs"))
         delete_button.add_css_class("destructive-action")
         delete_button.connect("clicked", lambda _: self._do_clear_logs(dialog))
         button_box.append(delete_button)
@@ -736,11 +737,11 @@ class DebugPage(PreferencesPageMixin):
         success = logging_config.clear_logs()
 
         if success:
-            self._show_toast("Logs cleared successfully")
+            self._show_toast(_("Logs cleared successfully"))
         else:
             self._show_simple_dialog(
-                "Clear Failed",
-                "Some log files could not be deleted. They may be in use or protected.",
+                _("Clear Failed"),
+                _("Some log files could not be deleted. They may be in use or protected."),
             )
 
         # Update size display

--- a/src/ui/preferences/scanner_page.py
+++ b/src/ui/preferences/scanner_page.py
@@ -783,7 +783,10 @@ class ScannerPage(PreferencesPageMixin):
         if not config:
             return
 
-        # Populate file type scanning switches
+        # Populate file type scanning switches. ClamAV enables all of these
+        # by default when the key is absent from clamd.conf, so a missing key
+        # must show as ON — defaulting to off would write "ScanPE no" etc. on
+        # the next save and silently disable executable/document scanning.
         for key in (
             "ScanPE",
             "ScanELF",
@@ -792,7 +795,7 @@ class ScannerPage(PreferencesPageMixin):
             "ScanHTML",
             "ScanArchive",
         ):
-            populate_bool_field(config, widgets_dict, key)
+            populate_bool_field(config, widgets_dict, key, default=True)
 
         # Populate performance settings
         for key in ("MaxFileSize", "MaxScanSize"):

--- a/src/ui/preferences/scheduled_page.py
+++ b/src/ui/preferences/scheduled_page.py
@@ -251,8 +251,14 @@ class ScheduledPage(PreferencesPageMixin):
             widgets_dict: Dictionary of widget references
 
         Returns:
-            Dictionary of scheduled scan settings to save
+            Dictionary of scheduled scan settings to save, or an empty dict
+            when the page was never created (no widgets to read). Returning
+            defaults in that case would silently overwrite the user's saved
+            schedule and disable the scheduler.
         """
+        if not widgets_dict:
+            return {}
+
         frequency_map = ["hourly", "daily", "weekly", "monthly"]
         selected_frequency = get_widget_selected(widgets_dict, "frequency")
         if selected_frequency is None or selected_frequency >= len(frequency_map):

--- a/src/ui/preferences/window.py
+++ b/src/ui/preferences/window.py
@@ -25,7 +25,7 @@ from ...core.flatpak import is_flatpak
 from ...core.i18n import N_, _
 from ...core.scheduler import Scheduler
 from ..compat import create_toolbar_view
-from ..utils import resolve_icon_name
+from ..utils import enable_escape_to_close, resolve_icon_name
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +145,7 @@ class PreferencesWindow(Adw.Window, PreferencesPageMixin):
         self.set_title(_("Preferences"))
         self.set_default_size(850, 600)
         self.set_modal(True)
+        enable_escape_to_close(self)
 
         # Store references to form widgets for later access
         self._freshclam_widgets = {}

--- a/src/ui/preferences/window.py
+++ b/src/ui/preferences/window.py
@@ -227,6 +227,7 @@ class PreferencesWindow(Adw.Window, PreferencesPageMixin):
 
         # Load configurations and populate form fields
         self._load_configs()
+        self._notify_load_errors()
 
         # Populate scheduled scan fields from saved settings
         self._populate_scheduled_fields()
@@ -604,6 +605,29 @@ class PreferencesWindow(Adw.Window, PreferencesPageMixin):
                 logger.exception("Unexpected error loading clamd.conf: %s", e)
                 self._clamd_load_error = str(e)
 
+    def _notify_load_errors(self):
+        """
+        Surface config load failures to the user.
+
+        _load_configs()/_reload_*_config() record parse errors in
+        _freshclam_load_error/_clamd_load_error; without a visible signal
+        the user silently edits an empty form and can save wrong values
+        over their real configuration.
+        """
+        if not hasattr(self, "_notified_load_errors"):
+            self._notified_load_errors = set()
+        for filename, error in (
+            ("freshclam.conf", self._freshclam_load_error),
+            ("clamd.conf", self._clamd_load_error),
+        ):
+            if error and (filename, error) not in self._notified_load_errors:
+                self._notified_load_errors.add((filename, error))
+                toast = Adw.Toast.new(
+                    _("Failed to load {file}: {error}").format(file=filename, error=error)
+                )
+                toast.set_timeout(0)  # persistent until dismissed
+                self.add_toast(toast)
+
     def _reload_clamd_config(self):
         """
         Re-parse clamd.conf after the path has changed.
@@ -624,6 +648,7 @@ class PreferencesWindow(Adw.Window, PreferencesPageMixin):
         except Exception as e:
             logger.exception("Unexpected error reloading clamd.conf: %s", e)
             self._clamd_load_error = str(e)
+        self._notify_load_errors()
 
     def _reload_freshclam_config(self):
         """
@@ -644,6 +669,7 @@ class PreferencesWindow(Adw.Window, PreferencesPageMixin):
         except Exception as e:
             logger.exception("Unexpected error reloading freshclam.conf: %s", e)
             self._freshclam_load_error = str(e)
+        self._notify_load_errors()
 
     def _populate_freshclam_fields(self):
         """

--- a/src/ui/profile_dialogs.py
+++ b/src/ui/profile_dialogs.py
@@ -20,6 +20,7 @@ from .compat import (
     create_entry_row,
     create_toolbar_view,
     open_paths_dialog,
+    remove_all_children,
     save_path_dialog,
 )
 from .utils import add_row_icon, resolve_icon_name
@@ -1136,8 +1137,8 @@ class ProfileListDialog(Adw.Window):
 
     def _refresh_profile_list(self):
         """Refresh the profile list from the profile manager."""
-        # Clear existing rows - use remove_all() for O(1) instead of O(n²) loop removal
-        self._profiles_listbox.remove_all()
+        # Clear existing rows (Gtk.ListBox.remove_all() requires GTK 4.12+)
+        remove_all_children(self._profiles_listbox)
 
         # Get profiles from manager
         if self._profile_manager is None:

--- a/src/ui/profile_dialogs.py
+++ b/src/ui/profile_dialogs.py
@@ -1139,8 +1139,14 @@ class ProfileListDialog(Adw.Window):
         scrolled.set_child(preferences_page)
         toolbar_view.set_content(scrolled)
 
-        # Set the toolbar view as the dialog content
-        self.set_content(toolbar_view)
+        # Wrap in a toast overlay so import/export can report their outcome
+        self._toast_overlay = Adw.ToastOverlay()
+        self._toast_overlay.set_child(toolbar_view)
+        self.set_content(self._toast_overlay)
+
+    def _show_toast(self, message: str) -> None:
+        """Show a transient toast message in this dialog."""
+        self._toast_overlay.add_toast(Adw.Toast.new(message))
 
     def _refresh_profile_list(self):
         """Refresh the profile list from the profile manager."""
@@ -1373,6 +1379,9 @@ class ProfileListDialog(Adw.Window):
             self._profile_manager.export_profile(profile_id, Path(file_path))
         except (ValueError, OSError) as e:
             logger.warning("Failed to export profile: %s", e)
+            self._show_toast(_("Failed to export profile: {error}").format(error=e))
+        else:
+            self._show_toast(_("Profile exported"))
 
     def _on_profile_saved(self, profile: "ScanProfile"):
         """
@@ -1421,3 +1430,6 @@ class ProfileListDialog(Adw.Window):
             self._refresh_profile_list()
         except (ValueError, OSError) as e:
             logger.warning("Failed to import profile: %s", e)
+            self._show_toast(_("Failed to import profile: {error}").format(error=e))
+        else:
+            self._show_toast(_("Profile imported"))

--- a/src/ui/profile_dialogs.py
+++ b/src/ui/profile_dialogs.py
@@ -727,6 +727,8 @@ class PatternEntryDialog(Adw.Window):
         add_button.set_label(_("Add"))
         add_button.add_css_class("suggested-action")
         add_button.connect("clicked", self._on_add_clicked)
+        # Disabled until a pattern is entered (see _on_pattern_changed)
+        add_button.set_sensitive(False)
         self._add_button = add_button
         header_bar.pack_end(add_button)
 

--- a/src/ui/profile_dialogs.py
+++ b/src/ui/profile_dialogs.py
@@ -23,7 +23,7 @@ from .compat import (
     remove_all_children,
     save_path_dialog,
 )
-from .utils import add_row_icon, resolve_icon_name
+from .utils import add_row_icon, enable_escape_to_close, resolve_icon_name
 
 if TYPE_CHECKING:
     from ..profiles.models import ScanProfile
@@ -107,6 +107,7 @@ class ProfileDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):
@@ -706,6 +707,7 @@ class PatternEntryDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         self._setup_ui()
@@ -826,6 +828,7 @@ class DeleteProfileDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         self._setup_ui()
@@ -947,6 +950,7 @@ class RestoreDefaultsDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         self._setup_ui()
@@ -1068,6 +1072,7 @@ class ProfileListDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):

--- a/src/ui/quarantine_view.py
+++ b/src/ui/quarantine_view.py
@@ -25,7 +25,7 @@ from ..core.quarantine import (
     QuarantineResult,
     QuarantineStatus,
 )
-from .compat import create_banner
+from .compat import create_banner, safe_set_placeholder_text
 from .pagination import PaginatedListController
 from .utils import add_row_icon, resolve_icon_name
 from .view_helpers import EmptyStateConfig, create_empty_state, create_loading_row
@@ -185,15 +185,10 @@ class QuarantineView(Gtk.Box):
         header_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         header_box.set_spacing(12)
 
-        # Search entry
+        # Search entry (placeholder text requires GTK 4.10+; skipped on older
+        # versions — setting the property there raises TypeError)
         self._search_entry = Gtk.SearchEntry()
-        # set_placeholder_text() requires GTK 4.10+; fall back to GObject property
-        if hasattr(self._search_entry, "set_placeholder_text"):
-            self._search_entry.set_placeholder_text(_("Search by threat name or path..."))
-        else:
-            self._search_entry.set_property(
-                "placeholder-text", _("Search by threat name or path...")
-            )
+        safe_set_placeholder_text(self._search_entry, _("Search by threat name or path..."))
         self._search_entry.set_hexpand(True)
         self._search_entry.connect("search-changed", self._on_search_changed)
         header_box.append(self._search_entry)

--- a/src/ui/quarantine_view.py
+++ b/src/ui/quarantine_view.py
@@ -16,7 +16,7 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, GLib, Gtk, Pango
+from gi.repository import Adw, GLib, GObject, Gtk, Pango
 
 from ..core.i18n import _, ngettext
 from ..core.quarantine import (
@@ -25,10 +25,107 @@ from ..core.quarantine import (
     QuarantineResult,
     QuarantineStatus,
 )
-from .compat import create_banner, safe_set_placeholder_text
+from .compat import create_banner, create_toolbar_view, safe_set_placeholder_text
 from .pagination import PaginatedListController
-from .utils import add_row_icon, resolve_icon_name
+from .utils import add_row_icon, enable_escape_to_close, resolve_icon_name
 from .view_helpers import EmptyStateConfig, create_empty_state, create_loading_row
+
+
+class QuarantineConfirmDialog(Adw.Window):
+    """
+    Confirmation dialog for irreversible or risky quarantine actions.
+
+    Uses Adw.Window instead of Adw.MessageDialog for compatibility with
+    libadwaita < 1.5 (Ubuntu 22.04, Pop!_OS 22.04).
+
+    Usage:
+        dialog = QuarantineConfirmDialog(
+            heading=_("Delete File?"),
+            body=_("This cannot be undone."),
+            confirm_label=_("Delete"),
+            destructive=True,
+        )
+        dialog.connect("response", on_response)  # "confirm" or "cancel"
+        dialog.set_transient_for(parent_window)
+        dialog.present()
+    """
+
+    __gsignals__ = {"response": (GObject.SignalFlags.RUN_LAST, None, (str,))}
+
+    def __init__(
+        self,
+        heading: str,
+        body: str,
+        confirm_label: str,
+        destructive: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._heading = heading
+        self._body = body
+
+        self.set_title(heading)
+        self.set_default_size(400, -1)  # Natural height
+        self.set_modal(True)
+        enable_escape_to_close(self)
+        self.set_deletable(True)
+
+        toolbar_view = create_toolbar_view()
+        toolbar_view.add_top_bar(Adw.HeaderBar())
+
+        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        content_box.set_margin_start(24)
+        content_box.set_margin_end(24)
+        content_box.set_margin_top(12)
+        content_box.set_margin_bottom(24)
+
+        warning_icon = Gtk.Image.new_from_icon_name(resolve_icon_name("dialog-warning-symbolic"))
+        warning_icon.set_pixel_size(48)
+        warning_icon.add_css_class("warning")
+        warning_icon.set_halign(Gtk.Align.CENTER)
+        content_box.append(warning_icon)
+
+        body_label = Gtk.Label()
+        body_label.set_text(body)
+        body_label.set_wrap(True)
+        body_label.set_xalign(0.5)
+        body_label.set_justify(Gtk.Justification.CENTER)
+        content_box.append(body_label)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        button_box.set_halign(Gtk.Align.CENTER)
+        button_box.set_margin_top(12)
+
+        cancel_button = Gtk.Button(label=_("Cancel"))
+        cancel_button.connect("clicked", self._on_cancel_clicked)
+        button_box.append(cancel_button)
+
+        confirm_button = Gtk.Button(label=confirm_label)
+        confirm_button.add_css_class("destructive-action" if destructive else "suggested-action")
+        confirm_button.connect("clicked", self._on_confirm_clicked)
+        button_box.append(confirm_button)
+
+        content_box.append(button_box)
+
+        toolbar_view.set_content(content_box)
+        self.set_content(toolbar_view)
+
+    def _on_cancel_clicked(self, button):
+        self.emit("response", "cancel")
+        self.close()
+
+    def _on_confirm_clicked(self, button):
+        self.emit("response", "confirm")
+        self.close()
+
+    def get_heading(self) -> str:
+        """Get the dialog heading/title (for test compatibility)."""
+        return self._heading
+
+    def get_body(self) -> str:
+        """Get the dialog body text (for test compatibility)."""
+        return self._body
 
 
 class _QuarantinePaginationController(PaginatedListController):
@@ -732,11 +829,31 @@ class QuarantineView(Gtk.Box):
         """
         Handle restore button click for a quarantine entry.
 
+        Asks for confirmation first: restoring puts a detected threat back
+        on disk at its original location.
+
         Args:
             button: The button that was clicked
             entry: The QuarantineEntry to restore
         """
-        self._manager.restore_file_async(entry.id, callback=self._on_restore_completed)
+        dialog = QuarantineConfirmDialog(
+            heading=_("Restore Quarantined File?"),
+            body=_(
+                'This file was detected as "{threat}". It will be restored to {path}.'
+            ).format(threat=entry.threat_name or _("Unknown Threat"), path=entry.original_path),
+            confirm_label=_("Restore Anyway"),
+            destructive=True,
+        )
+        dialog.connect("response", self._on_restore_confirm_response, entry)
+        root = self.get_root()
+        if isinstance(root, Gtk.Window):
+            dialog.set_transient_for(root)
+        dialog.present()
+
+    def _on_restore_confirm_response(self, dialog, response: str, entry: QuarantineEntry):
+        """Start the restore once the user confirms."""
+        if response == "confirm":
+            self._manager.restore_file_async(entry.id, callback=self._on_restore_completed)
 
     def _on_restore_completed(self, result: QuarantineResult) -> bool:
         """
@@ -763,11 +880,32 @@ class QuarantineView(Gtk.Box):
         """
         Handle delete button click for a quarantine entry.
 
+        Asks for confirmation first: deletion permanently destroys the file
+        with no way to recover it.
+
         Args:
             button: The button that was clicked
             entry: The QuarantineEntry to delete
         """
-        self._manager.delete_file_async(entry.id, callback=self._on_delete_completed)
+        dialog = QuarantineConfirmDialog(
+            heading=_("Permanently Delete File?"),
+            body=_(
+                'The quarantined file from {path} ("{threat}") will be permanently '
+                "deleted. This action cannot be undone."
+            ).format(path=entry.original_path, threat=entry.threat_name or _("Unknown Threat")),
+            confirm_label=_("Delete"),
+            destructive=True,
+        )
+        dialog.connect("response", self._on_delete_confirm_response, entry)
+        root = self.get_root()
+        if isinstance(root, Gtk.Window):
+            dialog.set_transient_for(root)
+        dialog.present()
+
+    def _on_delete_confirm_response(self, dialog, response: str, entry: QuarantineEntry):
+        """Start the delete once the user confirms."""
+        if response == "confirm":
+            self._manager.delete_file_async(entry.id, callback=self._on_delete_completed)
 
     def _on_delete_completed(self, result: QuarantineResult) -> bool:
         """

--- a/src/ui/quarantine_view.py
+++ b/src/ui/quarantine_view.py
@@ -237,7 +237,7 @@ class QuarantineView(Gtk.Box):
         # Create the status banner (hidden by default)
         self._status_banner = create_banner()
         self._status_banner.set_revealed(False)
-        self._status_banner.set_button_label("Dismiss")
+        self._status_banner.set_button_label(_("Dismiss"))
         self._status_banner.connect("button-clicked", self._on_status_banner_dismissed)
         self.append(self._status_banner)
 
@@ -440,7 +440,7 @@ class QuarantineView(Gtk.Box):
 
             # Use controller to display entries with pagination
             # Always pass all_entries - controller's entries_to_display override handles filtering
-            entries_label = "filtered entries" if self._search_query else "entries"
+            entries_label = _("filtered entries") if self._search_query else _("entries")
             self._pagination.set_entries(self._all_entries, entries_label)
 
             # Enable clear old button if there are entries
@@ -499,7 +499,7 @@ class QuarantineView(Gtk.Box):
         if hasattr(self, "_pagination"):
             self._pagination.display_batch(start_index, count)
 
-    def _add_load_more_button(self, entries_label: str = "entries"):
+    def _add_load_more_button(self, entries_label: str | None = None):
         """Add load more button (backward compatibility - delegates to pagination controller)."""
         if hasattr(self, "_pagination"):
             self._pagination.add_load_more_button(entries_label)
@@ -627,7 +627,7 @@ class QuarantineView(Gtk.Box):
         # Reset controller and provide all entries
         # Controller's overridden entries_to_display property will return filtered entries
         # This allows controller to maintain full dataset while displaying filtered results
-        entries_label = "filtered entries" if self._search_query else "entries"
+        entries_label = _("filtered entries") if self._search_query else _("entries")
         self._pagination.set_entries(self._all_entries, entries_label)
 
     def _on_cleanup_completed(self, removed_count: int) -> bool:
@@ -838,9 +838,9 @@ class QuarantineView(Gtk.Box):
         """
         dialog = QuarantineConfirmDialog(
             heading=_("Restore Quarantined File?"),
-            body=_(
-                'This file was detected as "{threat}". It will be restored to {path}.'
-            ).format(threat=entry.threat_name or _("Unknown Threat"), path=entry.original_path),
+            body=_('This file was detected as "{threat}". It will be restored to {path}.').format(
+                threat=entry.threat_name or _("Unknown Threat"), path=entry.original_path
+            ),
             confirm_label=_("Restore Anyway"),
             destructive=True,
         )

--- a/src/ui/scan/scan_controller.py
+++ b/src/ui/scan/scan_controller.py
@@ -216,11 +216,16 @@ class ScanController:
                 result.error_messages.append(str(exc))
         finally:
             self._state = ScanState.IDLE
-            if self._on_state_change:
-                GLib.idle_add(self._on_state_change, self._state)
-
+            # Deliver the result BEFORE the state change: idle callbacks run
+            # FIFO, and state-change consumers (tray status, coordinator) read
+            # the current result — firing IDLE first would hand them the
+            # previous scan's result (or None) and e.g. show a "protected"
+            # tray icon right after threats were found.
             if self._on_complete:
                 GLib.idle_add(self._on_complete, result.to_scan_result(paths))
+
+            if self._on_state_change:
+                GLib.idle_add(self._on_state_change, self._state)
 
     def _aggregate_result(self, agg: AggregatedResult, scan: ScanResult):
         """Add scan result to aggregated total."""

--- a/src/ui/scan/scan_progress_widget.py
+++ b/src/ui/scan/scan_progress_widget.py
@@ -19,6 +19,7 @@ from gi.repository import Adw, GLib, Gtk
 
 from ...core.i18n import _, ngettext
 from ...core.scanner import ScanProgress
+from ..compat import safe_set_subtitle_lines
 from ..utils import resolve_icon_name
 
 
@@ -70,7 +71,7 @@ class ScanProgressWidget(Gtk.Box):
         self._current_file_row = Adw.ActionRow()
         self._current_file_row.set_title(_("Currently scanning"))
         self._current_file_row.set_subtitle(_("Waiting for scan data..."))
-        self._current_file_row.set_subtitle_lines(1)
+        safe_set_subtitle_lines(self._current_file_row, 1)
         self._file_spinner = Gtk.Spinner()
         self._file_spinner.set_spinning(True)
         self._current_file_row.add_prefix(self._file_spinner)

--- a/src/ui/scan/scan_progress_widget.py
+++ b/src/ui/scan/scan_progress_widget.py
@@ -204,11 +204,14 @@ class ScanProgressWidget(Gtk.Box):
             )
             self._stats_row.set_subtitle("")
 
-        # Append new threats
+        # Append new threats. Bump the counter per row so the group title
+        # counts correctly when several threats arrive in one update, then
+        # sync to the authoritative count (infected_files can lag it).
         if progress.infected_count > self._live_threat_count:
             threats = progress.infected_threats or {}
             for file_path in progress.infected_files[self._live_threat_count :]:
                 threat_name = threats.get(file_path, _("Unknown threat"))
+                self._live_threat_count += 1
                 self._append_threat_row(file_path, threat_name)
             self._live_threat_count = progress.infected_count
 
@@ -233,8 +236,8 @@ class ScanProgressWidget(Gtk.Box):
             ngettext(
                 "Threats Detected ({n})",
                 "Threats Detected ({n})",
-                self._live_threat_count + 1,
-            ).format(n=self._live_threat_count + 1)
+                self._live_threat_count,
+            ).format(n=self._live_threat_count)
         )
         self._threat_group.set_visible(True)
 

--- a/src/ui/scan/scan_view.py
+++ b/src/ui/scan/scan_view.py
@@ -71,8 +71,10 @@ class ScanView(Gtk.Box):
         self._eicar_temp_path = ""
 
         self._setup_css()
-        self._setup_ui()
+        # The controller must exist before the UI: _setup_ui() builds the
+        # backend indicator from self._scanner.
         self._setup_controller()
+        self._setup_ui()
 
     def _setup_css(self):
         css_provider = Gtk.CssProvider()
@@ -280,7 +282,13 @@ class ScanView(Gtk.Box):
         self._cancel_btn.set_visible(True)
         self._status_banner.set_revealed(False)
         self._results_widget.hide()
-        self._progress_widget.start()
+        # Match the controller: with live progress off it creates no progress
+        # callback, so the file/stats rows would sit on "Waiting for scan
+        # data..." forever if shown.
+        show_live = True
+        if self._settings_manager:
+            show_live = self._settings_manager.get("show_live_progress", True)
+        self._progress_widget.start(show_live_progress=show_live)
         self._progress_widget.set_status(_("Scanning..."))
 
         self._controller.start_scan(

--- a/src/ui/scan/target_selector.py
+++ b/src/ui/scan/target_selector.py
@@ -16,7 +16,7 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, Gdk, GObject, Gtk
+from gi.repository import Adw, Gdk, GObject, Gtk, Pango
 
 from ...core.i18n import _
 from ...core.utils import format_scan_path, validate_dropped_files
@@ -43,19 +43,19 @@ class PathRow(Gtk.ListBoxRow):
         icon = Gtk.Image.new_from_icon_name(resolve_icon_name(icon_name))
         box.append(icon)
 
-        display = format_scan_path(path)
-        if len(display) > 50:
-            display = "..." + display[-47:]
-        label = Gtk.Label(label=display)
+        label = Gtk.Label(label=format_scan_path(path))
         label.set_hexpand(True)
         label.set_xalign(0)
-        label.set_ellipsize(True)
+        label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+        label.set_tooltip_text(path)
         box.append(label)
 
         remove_btn = Gtk.Button()
         remove_btn.set_icon_name(resolve_icon_name("window-close-symbolic"))
         remove_btn.add_css_class("flat")
         remove_btn.set_valign(Gtk.Align.CENTER)
+        remove_btn.set_tooltip_text(_("Remove target"))
+        remove_btn.update_property([Gtk.AccessibleProperty.LABEL], [_("Remove target")])
         remove_btn.connect("clicked", self._on_remove_clicked)
         box.append(remove_btn)
 

--- a/src/ui/scan_in_progress_dialog.py
+++ b/src/ui/scan_in_progress_dialog.py
@@ -13,6 +13,7 @@ from gi.repository import Adw, Gtk
 
 from ..core.i18n import _
 from .compat import create_toolbar_view
+from .utils import enable_escape_to_close
 
 
 class ScanInProgressDialog(Adw.Window):
@@ -67,6 +68,7 @@ class ScanInProgressDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
         # Connect to close-request signal for when user dismisses without choosing

--- a/src/ui/scan_results_dialog.py
+++ b/src/ui/scan_results_dialog.py
@@ -117,10 +117,11 @@ class ScanResultsDialog(Adw.Window):
         # Create header bar with actions
         header_bar = Adw.HeaderBar()
 
-        # Export button (left side)
+        # Copy-results button (left side). Copies to clipboard; very large
+        # results are redirected to a file-export dialog.
         export_button = Gtk.Button()
-        export_button.set_icon_name(resolve_icon_name("document-save-symbolic"))
-        export_button.set_tooltip_text(_("Export results"))
+        export_button.set_icon_name(resolve_icon_name("edit-copy-symbolic"))
+        export_button.set_tooltip_text(_("Copy results to clipboard"))
         export_button.add_css_class("flat")
         export_button.connect("clicked", self._on_export_clicked)
         header_bar.pack_start(export_button)

--- a/src/ui/scan_results_dialog.py
+++ b/src/ui/scan_results_dialog.py
@@ -369,6 +369,13 @@ class ScanResultsDialog(Adw.Window):
         if self._threats_list is None:
             return
 
+        # Remove the previous "Show more" row first so new rows keep list
+        # order and the button doesn't linger when the final batch exactly
+        # exhausts the list.
+        if self._load_more_row is not None:
+            self._threats_list.remove(self._load_more_row)
+            self._load_more_row = None
+
         start_idx = self._displayed_threat_count
         end_idx = min(start_idx + count, len(self._all_threat_details))
 
@@ -379,9 +386,6 @@ class ScanResultsDialog(Adw.Window):
 
         # Add "Load More" button if there are more threats
         if self._displayed_threat_count < len(self._all_threat_details):
-            if self._load_more_row is not None:
-                self._threats_list.remove(self._load_more_row)
-
             load_more_row = Gtk.ListBoxRow()
             load_more_row.add_css_class("load-more-row")
             load_more_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)

--- a/src/ui/scan_results_dialog.py
+++ b/src/ui/scan_results_dialog.py
@@ -22,7 +22,7 @@ from ..core.utils import format_flatpak_portal_path
 from .clipboard_helper import ClipboardHelper
 from .compat import create_toolbar_view, safe_add_suffix
 from .file_export import TEXT_FILTER, FileExportHelper
-from .utils import resolve_icon_name
+from .utils import enable_escape_to_close, resolve_icon_name
 
 if TYPE_CHECKING:
     from ..core.settings_manager import SettingsManager
@@ -103,6 +103,7 @@ class ScanResultsDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):

--- a/src/ui/scan_view.py
+++ b/src/ui/scan_view.py
@@ -24,7 +24,7 @@ from ..core.utils import (
     validate_dropped_files,
 )
 from .clipboard_helper import ClipboardHelper
-from .compat import create_banner, open_paths_dialog
+from .compat import create_banner, open_paths_dialog, safe_set_subtitle_lines
 from .eicar_helper import (
     EICAR_TEST_STRING as _EICAR_HELPER_STRING,
 )
@@ -1309,7 +1309,7 @@ class ScanView(Gtk.Box):
         self._current_file_row = Adw.ActionRow()
         self._current_file_row.set_title(_("Currently scanning"))
         self._current_file_row.set_subtitle(_("Waiting for scan data..."))
-        self._current_file_row.set_subtitle_lines(1)
+        safe_set_subtitle_lines(self._current_file_row, 1)
         # Spinner prefix
         self._file_spinner = Gtk.Spinner()
         self._file_spinner.set_spinning(True)

--- a/src/ui/statistics_view.py
+++ b/src/ui/statistics_view.py
@@ -1084,12 +1084,22 @@ class StatisticsView(Gtk.Box):
             timeframe: The timeframe value associated with the button
         """
         if not button.get_active():
+            # Clicking the already-active toggle deactivates it, which would
+            # leave no timeframe selected; re-activate to behave like a radio
+            # group.
+            if timeframe == self._current_timeframe:
+                button.set_active(True)
             return
 
         # Deactivate other buttons
         for tf, btn in self._timeframe_buttons.items():
             if tf != timeframe:
                 btn.set_active(False)
+
+        if timeframe == self._current_timeframe:
+            # Re-activation of the current selection (initial setup or the
+            # radio-guard above) — nothing new to load.
+            return
 
         # Update current timeframe and reload
         self._current_timeframe = timeframe

--- a/src/ui/tray_manager.py
+++ b/src/ui/tray_manager.py
@@ -320,7 +320,10 @@ class TrayManager:
                 self._respawn_count = 0
             self._respawn_count += 1
             self._last_respawn_time = now
-            # Clear stale process so start() will spawn a new one.
+            # Close the dead process's pipes before dropping the reference —
+            # a crash-looping subprocess would otherwise leak three fds per
+            # respawn. Then clear it so start() will spawn a new one.
+            self._close_pipes()
             self._process = None
             self._running = False
 

--- a/src/ui/update_view.py
+++ b/src/ui/update_view.py
@@ -346,10 +346,14 @@ class UpdateView(Gtk.Box):
         Returns:
             False to remove from idle (GLib.SOURCE_REMOVE)
         """
-        # Guard against widget being destroyed before callback fires
+        # Guard against widget being destroyed before callback fires. Do NOT
+        # bail out merely because the view is unmapped: it is cached for the
+        # app's lifetime and this check runs only once, so dropping the
+        # result while the user is on another view would leave the buttons
+        # stuck on "Checking freshclam..." forever. Updating an unmapped
+        # (but alive) widget is safe; a destroyed one raises and is caught.
         try:
-            if not self.get_mapped():
-                return False
+            self.get_mapped()
         except Exception:
             logger.debug(
                 "Skipping freshclam status update because the widget is unavailable",

--- a/src/ui/utils.py
+++ b/src/ui/utils.py
@@ -159,6 +159,33 @@ def add_row_icon(row: Adw.ActionRow | Adw.ExpanderRow, icon_name: str) -> Gtk.Im
     return icon
 
 
+def enable_escape_to_close(window: Gtk.Window) -> None:
+    """
+    Make Escape close a dialog window.
+
+    The project's dialogs are Adw.Window subclasses (for libadwaita 1.1
+    compatibility), which — unlike Gtk.Dialog/Adw.MessageDialog — do not
+    bind Escape by default. GNOME HIG expects every dialog to close on
+    Escape; call this from the dialog's __init__.
+
+    Closing goes through Gtk.Window.close(), so close-request handlers
+    (the same path as the titlebar close button) still run.
+    """
+
+    def _on_escape(widget, args):
+        window.close()
+        return True
+
+    controller = Gtk.ShortcutController()
+    controller.add_shortcut(
+        Gtk.Shortcut.new(
+            Gtk.ShortcutTrigger.parse_string("Escape"),
+            Gtk.CallbackAction.new(_on_escape),
+        )
+    )
+    window.add_controller(controller)
+
+
 def present_dialog(dialog: Adw.Window, parent: Gtk.Window) -> None:
     """
     Present a modal dialog window with proper parent relationship.

--- a/src/ui/virustotal_results_dialog.py
+++ b/src/ui/virustotal_results_dialog.py
@@ -104,10 +104,11 @@ class VirusTotalResultsDialog(Adw.Window):
         # Create header bar with actions
         header_bar = Adw.HeaderBar()
 
-        # Export button (left side)
+        # Copy-results button (left side). Copies JSON to clipboard; very
+        # large results are redirected to a file-export dialog.
         export_button = Gtk.Button()
-        export_button.set_icon_name(resolve_icon_name("document-save-symbolic"))
-        export_button.set_tooltip_text(_("Export results to JSON"))
+        export_button.set_icon_name(resolve_icon_name("edit-copy-symbolic"))
+        export_button.set_tooltip_text(_("Copy results as JSON"))
         export_button.add_css_class("flat")
         export_button.connect("clicked", self._on_export_clicked)
         header_bar.pack_start(export_button)

--- a/src/ui/virustotal_results_dialog.py
+++ b/src/ui/virustotal_results_dialog.py
@@ -22,7 +22,7 @@ from ..core.clipboard import copy_to_clipboard
 from ..core.i18n import _
 from ..core.virustotal import VTScanResult, VTScanStatus
 from .compat import create_toolbar_view
-from .utils import resolve_icon_name
+from .utils import enable_escape_to_close, resolve_icon_name
 
 if TYPE_CHECKING:
     pass
@@ -90,6 +90,7 @@ class VirusTotalResultsDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):

--- a/src/ui/virustotal_results_dialog.py
+++ b/src/ui/virustotal_results_dialog.py
@@ -312,6 +312,13 @@ class VirusTotalResultsDialog(Adw.Window):
         if self._detections_list is None:
             return
 
+        # Remove the previous "Show more" row first so new rows keep list
+        # order and the button doesn't linger when the final batch exactly
+        # exhausts the list.
+        if self._load_more_row is not None:
+            self._detections_list.remove(self._load_more_row)
+            self._load_more_row = None
+
         start_idx = self._displayed_detection_count
         end_idx = min(start_idx + count, len(self._all_detections))
 
@@ -322,9 +329,6 @@ class VirusTotalResultsDialog(Adw.Window):
 
         # Add "Load More" button if there are more detections
         if self._displayed_detection_count < len(self._all_detections):
-            if self._load_more_row is not None:
-                self._detections_list.remove(self._load_more_row)
-
             load_more_row = Gtk.ListBoxRow()
             load_more_row.add_css_class("load-more-row")
             load_more_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)

--- a/src/ui/virustotal_setup_dialog.py
+++ b/src/ui/virustotal_setup_dialog.py
@@ -23,7 +23,7 @@ from gi.repository import Adw, Gtk
 from ..core.i18n import _
 from ..core.keyring_manager import set_api_key, validate_api_key_format
 from .compat import create_switch_row, create_toolbar_view
-from .utils import resolve_icon_name
+from .utils import enable_escape_to_close, resolve_icon_name
 
 if TYPE_CHECKING:
     from ..core.settings_manager import SettingsManager
@@ -89,6 +89,7 @@ class VirusTotalSetupDialog(Adw.Window):
 
         # Configure as modal dialog
         self.set_modal(True)
+        enable_escape_to_close(self)
         self.set_deletable(True)
 
     def _setup_ui(self):

--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -167,11 +167,11 @@ class MainWindow(Adw.ApplicationWindow):
 
         logger.debug("Window minimized to tray")
 
-        # Update tray menu label if tray is available
+        # Update tray menu label if tray is available (window is now hidden)
         if hasattr(self._application, "tray_indicator"):
             tray = self._application.tray_indicator
             if tray is not None and hasattr(tray, "update_window_menu_label"):
-                tray.update_window_menu_label()
+                tray.update_window_menu_label(visible=False)
 
         return False  # Remove from idle queue
 

--- a/tests/core/test_log_manager.py
+++ b/tests/core/test_log_manager.py
@@ -955,16 +955,37 @@ class TestLogManagerDaemonStatus:
     def test_get_daemon_status_stopped(self, log_manager):
         """Test daemon status when clamd service is installed but not active."""
         with mock.patch("src.core.log_manager.which_host_command", return_value="/usr/bin/clamd"):
-            with mock.patch("subprocess.run") as mock_run:
-                mock_run.side_effect = [
-                    mock.Mock(stdout="failed\n"),
-                    mock.Mock(stdout="unknown\n"),
-                    mock.Mock(stdout="unknown\n"),
-                    mock.Mock(returncode=1),
-                ]
-                status, message = log_manager.get_daemon_status()
-                assert status == DaemonStatus.STOPPED
-                assert "not active" in message.lower()
+            with mock.patch(
+                "src.core.clamav_detection.systemd_unit_exists", return_value=True
+            ) as mock_exists:
+                with mock.patch("subprocess.run") as mock_run:
+                    mock_run.side_effect = [
+                        mock.Mock(stdout="failed\n"),
+                        mock.Mock(stdout="unknown\n"),
+                        mock.Mock(stdout="unknown\n"),
+                        mock.Mock(returncode=1),
+                    ]
+                    status, message = log_manager.get_daemon_status()
+                    assert status == DaemonStatus.STOPPED
+                    assert "not active" in message.lower()
+                    mock_exists.assert_called_once_with("clamav-daemon.service")
+
+    def test_get_daemon_status_not_installed_when_units_unknown(self, log_manager):
+        """systemd reports 'inactive' even for unknown units; without a clamd
+        binary and with no real unit, the status must be NOT_INSTALLED rather
+        than 'installed but not active'."""
+        with mock.patch("src.core.log_manager.which_host_command", return_value=None):
+            with mock.patch("src.core.clamav_detection.systemd_unit_exists", return_value=False):
+                with mock.patch("subprocess.run") as mock_run:
+                    mock_run.side_effect = [
+                        mock.Mock(stdout="inactive\n"),
+                        mock.Mock(stdout="inactive\n"),
+                        mock.Mock(stdout="inactive\n"),
+                        mock.Mock(returncode=1),
+                    ]
+                    status, message = log_manager.get_daemon_status()
+                    assert status == DaemonStatus.NOT_INSTALLED
+                    assert "not installed" in message.lower()
 
     def test_get_daemon_status_falls_back_to_process_when_systemctl_fails(self, log_manager):
         """Test daemon status falls back to pgrep when systemctl calls fail."""

--- a/tests/core/test_scanner.py
+++ b/tests/core/test_scanner.py
@@ -1289,6 +1289,21 @@ class TestPatternUtilities:
         assert compiled.match("/tmp/subdir")
         assert not compiled.match("/var/tmp/file")
 
+    def test_glob_to_regex_literal_trailing_dollar_is_anchored(self):
+        """A glob ending in a literal '$' must still get the end anchor.
+
+        'backup$' translates to r'backup\\$'; treating that escaped dollar
+        as the anchor left the pattern end-unanchored, silently excluding
+        every path that merely starts with 'backup$'.
+        """
+        import re
+
+        regex = glob_to_regex("backup$")
+        assert regex.endswith("\\$$")
+        compiled = re.compile(regex)
+        assert compiled.fullmatch("backup$")
+        assert not compiled.match("backup$2024.tar")
+
     def test_glob_to_regex_multiple_wildcards(self):
         """Test glob_to_regex handles multiple wildcards."""
         regex = glob_to_regex("*.test.*")

--- a/tests/core/test_scanner_base.py
+++ b/tests/core/test_scanner_base.py
@@ -228,6 +228,82 @@ class TestStreamProcessOutput:
         assert "/path/file2.txt: OK" in lines
         assert "/path/file3.txt: FOUND" in lines
 
+    def test_stream_output_partial_line_not_duplicated_in_stdout(self):
+        """A trailing partial line must appear exactly once in accumulated stdout.
+
+        The streaming loop appends every raw chunk to the stdout buffer as it
+        arrives, while separately tracking the trailing partial line for the
+        line callback. The exit-drain path used to re-append that partial
+        line, corrupting the final output (e.g. 'Scanned files: 1' +
+        'Scanned files: 123') and breaking result parsing.
+        """
+        mock_process = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+
+        # First iteration: process running, chunk ends mid-line.
+        # Second iteration: process exited, drain returns the rest.
+        mock_process.poll.side_effect = [None, 0]
+        mock_process.stdout = mock_stdout
+        mock_process.stderr = mock_stderr
+        mock_stdout.fileno.return_value = 1
+        mock_stderr.fileno.return_value = 2
+
+        lines = []
+
+        with (
+            patch("src.core.scanner_base.select.select", return_value=([1], [], [])),
+            patch(
+                "src.core.scanner_base.os.read",
+                side_effect=[
+                    b"Infected files: 0\nScanned files: 1",  # streaming read (partial line)
+                    b"23\n",  # drain stdout after poll
+                    b"",  # stdout EOF
+                    b"",  # stderr EOF
+                ],
+            ),
+        ):
+            stdout, _stderr, cancelled = stream_process_output(
+                mock_process, lambda: False, lines.append
+            )
+
+        assert cancelled is False
+        assert stdout == "Infected files: 0\nScanned files: 123\n"
+        assert lines == ["Infected files: 0", "Scanned files: 123"]
+
+    def test_stream_output_final_incomplete_line_flushed_once(self):
+        """A final line without trailing newline reaches the callback once and
+        is not duplicated in the accumulated stdout buffer."""
+        mock_process = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+
+        mock_process.poll.side_effect = [None, 0]
+        mock_process.stdout = mock_stdout
+        mock_process.stderr = mock_stderr
+        mock_stdout.fileno.return_value = 1
+        mock_stderr.fileno.return_value = 2
+
+        lines = []
+
+        with (
+            patch("src.core.scanner_base.select.select", return_value=([1], [], [])),
+            patch(
+                "src.core.scanner_base.os.read",
+                side_effect=[
+                    b"line1\nno newline at end",  # streaming read
+                    b"",  # drain stdout after poll (EOF, nothing new)
+                    b"",  # stderr EOF
+                ],
+            ),
+        ):
+            stdout, _stderr, _cancelled = stream_process_output(
+                mock_process, lambda: False, lines.append
+            )
+
+        assert stdout == "line1\nno newline at end"
+        assert lines == ["line1", "no newline at end"]
+
     def test_stream_output_does_not_deadlock_on_large_stderr(self):
         """Regression test for issue #146: full scan hanging at ~72%.
 

--- a/tests/core/test_updater.py
+++ b/tests/core/test_updater.py
@@ -1884,11 +1884,18 @@ class TestCheckFreshclamService:
 
         def mock_run(cmd, *args, **kwargs):
             calls.append(cmd)
+            if "show" in cmd:
+                # LoadState probe confirming the unit exists
+                return MagicMock(returncode=0, stdout="loaded\n")
             return MagicMock(returncode=3, stdout="inactive")
 
         with (
             patch(
                 "src.core.updater.wrap_host_command",
+                side_effect=lambda cmd: ["flatpak-spawn", "--host", *cmd],
+            ),
+            patch(
+                "src.core.clamav_detection.wrap_host_command",
                 side_effect=lambda cmd: ["flatpak-spawn", "--host", *cmd],
             ),
             patch("subprocess.run", side_effect=mock_run),
@@ -1939,18 +1946,49 @@ class TestCheckFreshclamService:
 
         mock_log_manager = MagicMock()
 
-        # Mock systemctl is-active returning inactive
-        mock_systemctl = MagicMock()
-        mock_systemctl.returncode = 0
-        mock_systemctl.stdout = "inactive"
+        # Mock systemctl is-active returning inactive for a unit that exists
+        def mock_run(cmd, *args, **kwargs):
+            if "show" in cmd:
+                # LoadState probe confirming the unit exists
+                return MagicMock(returncode=0, stdout="loaded\n")
+            return MagicMock(returncode=3, stdout="inactive")
 
         with patch("src.core.updater.is_flatpak", return_value=False):
-            with patch("subprocess.run", return_value=mock_systemctl):
+            with patch("subprocess.run", side_effect=mock_run):
                 with patch("src.core.updater.wrap_host_command", side_effect=lambda x: x):
-                    updater = FreshclamUpdater(log_manager=mock_log_manager)
-                    status, pid = updater.check_freshclam_service()
+                    with patch(
+                        "src.core.clamav_detection.wrap_host_command", side_effect=lambda x: x
+                    ):
+                        updater = FreshclamUpdater(log_manager=mock_log_manager)
+                        status, pid = updater.check_freshclam_service()
 
         assert status == FreshclamServiceStatus.STOPPED
+        assert pid is None
+
+    def test_returns_not_found_when_unit_unknown_but_reported_inactive(self, updater_module):
+        """systemd prints 'inactive' for units it has never heard of; that
+        must not be classified as installed-but-stopped, or the second
+        candidate unit name (openSUSE's freshclam.service) is never probed."""
+        from src.core.updater import FreshclamServiceStatus, FreshclamUpdater
+
+        mock_log_manager = MagicMock()
+
+        def mock_run(cmd, *args, **kwargs):
+            if "show" in cmd:
+                # LoadState probe: unit is unknown to systemd
+                return MagicMock(returncode=0, stdout="not-found\n")
+            return MagicMock(returncode=3, stdout="inactive")
+
+        with patch("src.core.updater.is_flatpak", return_value=False):
+            with patch("subprocess.run", side_effect=mock_run):
+                with patch("src.core.updater.wrap_host_command", side_effect=lambda x: x):
+                    with patch(
+                        "src.core.clamav_detection.wrap_host_command", side_effect=lambda x: x
+                    ):
+                        updater = FreshclamUpdater(log_manager=mock_log_manager)
+                        status, pid = updater.check_freshclam_service()
+
+        assert status == FreshclamServiceStatus.NOT_FOUND
         assert pid is None
 
     def test_returns_not_found_when_no_service_exists(self, updater_module):

--- a/tests/ui/preferences/test_database_page.py
+++ b/tests/ui/preferences/test_database_page.py
@@ -450,6 +450,18 @@ class TestDatabasePageCollectData:
         assert "Checks" not in result
         assert "DatabaseDirectory" not in result
 
+    def test_collect_data_returns_empty_when_page_never_created(self, mock_gi_modules):
+        """collect_data must return {} for an empty widgets dict.
+
+        Collecting from an empty dict would include an empty
+        DatabaseCustomURL list, which Save & Apply translates into
+        remove_key("DatabaseCustomURL") — stripping the user's custom
+        signature URLs even though the Database page was never opened.
+        """
+        from src.ui.preferences.database_page import DatabasePage
+
+        assert DatabasePage.collect_data({}) == {}
+
     def test_collect_data_skips_invalid_numeric_values(self, mock_gi_modules, mock_widgets):
         """Test collect_data ignores invalid numeric values instead of raising."""
         from src.ui.preferences.database_page import DatabasePage

--- a/tests/ui/preferences/test_scanner_page.py
+++ b/tests/ui/preferences/test_scanner_page.py
@@ -922,9 +922,10 @@ class TestScannerPagePopulateFields:
 
         ScannerPage.populate_fields(mock_config, mock_widgets)
 
-        # Should call set_active with default value (False) for missing boolean keys
-        # This is the new behavior - populate_bool_field now sets default values
-        mock_widgets["ScanPE"].set_active.assert_called_with(False)
+        # Missing file-type keys must default to ON: ClamAV enables ScanPE etc.
+        # by default when absent from clamd.conf, so showing them off would
+        # write "ScanPE no" on the next save and disable scanning features.
+        mock_widgets["ScanPE"].set_active.assert_called_with(True)
         # set_value should not be called for missing numeric keys (different helper)
         mock_widgets["MaxFileSize"].set_value.assert_not_called()
 

--- a/tests/ui/preferences/test_scheduled_page.py
+++ b/tests/ui/preferences/test_scheduled_page.py
@@ -610,22 +610,16 @@ class TestScheduledPageCollectData:
         for key in required_keys:
             assert key in result, f"Required key {key} not in result"
 
-    def test_collect_data_handles_missing_widgets_with_defaults(self, mock_gi_modules):
-        """Test collect_data returns safe defaults when widgets are missing."""
+    def test_collect_data_returns_empty_when_page_never_created(self, mock_gi_modules):
+        """collect_data must not fabricate defaults when the page has no widgets.
+
+        Returning defaults for an empty widgets dict would overwrite the
+        user's saved schedule (and disable the scheduler) whenever Save &
+        Apply runs without the Scheduled page ever being opened.
+        """
         from src.ui.preferences.scheduled_page import ScheduledPage
 
-        result = ScheduledPage.collect_data({})
-
-        assert result == {
-            "scheduled_scans_enabled": False,
-            "schedule_frequency": "daily",
-            "schedule_time": "02:00",
-            "schedule_targets": [],
-            "schedule_day_of_week": 0,
-            "schedule_day_of_month": 1,
-            "schedule_skip_on_battery": True,
-            "schedule_auto_quarantine": False,
-        }
+        assert ScheduledPage.collect_data({}) == {}
 
     def test_collect_data_handles_invalid_numeric_values(self, mock_gi_modules, widgets_dict):
         """Test collect_data falls back to defaults on invalid numeric values."""

--- a/tests/ui/test_logs_view.py
+++ b/tests/ui/test_logs_view.py
@@ -615,14 +615,16 @@ class TestLogsViewExportDaemonLogs:
 
     def test_export_daemon_logs_skips_placeholder(self, logs_view_class):
         """Test that export skips placeholder text."""
+        placeholder = (
+            "Daemon logs will appear here.\n\nClick the play button to start live updates."
+        )
         view = object.__new__(logs_view_class)
         view._daemon_text = mock.MagicMock()
+        view._daemon_placeholder_text = placeholder
         mock_buffer = mock.MagicMock()
         mock_buffer.get_start_iter.return_value = mock.MagicMock()
         mock_buffer.get_end_iter.return_value = mock.MagicMock()
-        mock_buffer.get_text.return_value = (
-            "Daemon logs will appear here.\n\nClick the play button to start live updates."
-        )
+        mock_buffer.get_text.return_value = placeholder
         view._daemon_text.get_buffer.return_value = mock_buffer
         view.get_root = mock.MagicMock(return_value=None)
 

--- a/tests/ui/test_pagination.py
+++ b/tests/ui/test_pagination.py
@@ -636,7 +636,8 @@ class TestPaginationControllerSetEntries:
         assert controller._displayed_count == 25
 
         # Should add load_more_button since there are more entries
-        controller.add_load_more_button.assert_called_once_with("entries")
+        # (default label is None; translated to "entries" at render time)
+        controller.add_load_more_button.assert_called_once_with(None)
 
     def test_set_entries_filtered_subset_below_limit_no_load_more(
         self, pagination_controller_class, mock_listbox, mock_scrolled_window, mock_gi_modules
@@ -853,7 +854,8 @@ class TestPaginationControllerLoadMore:
         controller.load_more()
 
         # Should re-add load_more_button since 10 entries remain
-        controller.add_load_more_button.assert_called_once_with("entries")
+        # (default label is None; translated to "entries" at render time)
+        controller.add_load_more_button.assert_called_once_with(None)
 
     def test_load_more_does_not_readd_button_when_all_displayed(
         self, pagination_controller_class, mock_listbox, mock_scrolled_window, mock_row_factory

--- a/tests/ui/test_quarantine_view.py
+++ b/tests/ui/test_quarantine_view.py
@@ -939,6 +939,56 @@ class TestQuarantineViewSearchIntegration:
         view._count_label.set_text.assert_called_with("1 of 2 items")
 
 
+class TestQuarantineViewConfirmations:
+    """Tests for the delete/restore confirmation flow."""
+
+    def test_delete_confirm_response_triggers_delete(
+        self, mock_quarantine_view, mock_quarantine_manager, mock_quarantine_entry
+    ):
+        """Confirming the dialog starts the async delete."""
+        mock_quarantine_view._on_delete_confirm_response(
+            mock.MagicMock(), "confirm", mock_quarantine_entry
+        )
+
+        mock_quarantine_manager.delete_file_async.assert_called_once()
+        assert (
+            mock_quarantine_manager.delete_file_async.call_args[0][0] == mock_quarantine_entry.id
+        )
+
+    def test_delete_cancel_response_does_not_delete(
+        self, mock_quarantine_view, mock_quarantine_manager, mock_quarantine_entry
+    ):
+        """Cancelling the dialog must not delete anything."""
+        mock_quarantine_view._on_delete_confirm_response(
+            mock.MagicMock(), "cancel", mock_quarantine_entry
+        )
+
+        mock_quarantine_manager.delete_file_async.assert_not_called()
+
+    def test_restore_confirm_response_triggers_restore(
+        self, mock_quarantine_view, mock_quarantine_manager, mock_quarantine_entry
+    ):
+        """Confirming the dialog starts the async restore."""
+        mock_quarantine_view._on_restore_confirm_response(
+            mock.MagicMock(), "confirm", mock_quarantine_entry
+        )
+
+        mock_quarantine_manager.restore_file_async.assert_called_once()
+        assert (
+            mock_quarantine_manager.restore_file_async.call_args[0][0] == mock_quarantine_entry.id
+        )
+
+    def test_restore_cancel_response_does_not_restore(
+        self, mock_quarantine_view, mock_quarantine_manager, mock_quarantine_entry
+    ):
+        """Cancelling the dialog must not restore anything."""
+        mock_quarantine_view._on_restore_confirm_response(
+            mock.MagicMock(), "cancel", mock_quarantine_entry
+        )
+
+        mock_quarantine_manager.restore_file_async.assert_not_called()
+
+
 class TestQuarantineViewStorageInfoExtended:
     """Extended tests for storage info with additional edge cases."""
 

--- a/tests/ui/test_quarantine_view.py
+++ b/tests/ui/test_quarantine_view.py
@@ -951,9 +951,7 @@ class TestQuarantineViewConfirmations:
         )
 
         mock_quarantine_manager.delete_file_async.assert_called_once()
-        assert (
-            mock_quarantine_manager.delete_file_async.call_args[0][0] == mock_quarantine_entry.id
-        )
+        assert mock_quarantine_manager.delete_file_async.call_args[0][0] == mock_quarantine_entry.id
 
     def test_delete_cancel_response_does_not_delete(
         self, mock_quarantine_view, mock_quarantine_manager, mock_quarantine_entry


### PR DESCRIPTION
## Summary

Full-project audit (core logic, UI layer, scan/preferences/CLI, UX) with fixes for 30+ verified issues across 13 commits. Highest-impact first:

### Data-loss fixes (Preferences → Save & Apply)
- **Saving without opening the Scheduled page silently disabled scheduled scans** and reset frequency/targets/time: `ScheduledPage.collect_data()` fabricated defaults from an empty widgets dict. It now returns `{}` when the page was never created.
- **Saving without opening the Database page stripped all `DatabaseCustomURL` entries** from freshclam.conf (and made the "No Changes to Apply" path unreachable). Same fix.
- **File-type scan switches (ScanPE/ScanELF/ScanOLE2/ScanPDF/ScanHTML/ScanArchive) defaulted to OFF** for keys absent from clamd.conf; ClamAV's built-in default is ON, so the next save wrote `ScanPE no` etc. and silently disabled executable/document/archive scanning.
- Reloading freshclam.conf (Detect/Browse) no longer duplicates custom-URL rows (and duplicated config lines on save).
- Config parse failures are now surfaced as a persistent toast — previously recorded but never shown, letting users edit an empty form and save it over their real config.

### Crashes on the supported baseline (Ubuntu 22.04: GTK 4.6 / libadwaita 1.1)
- `Gtk.ListBox.remove_all()` (GTK 4.12+) crashed the **Manage Profiles dialog** on open and broke the logs view's loading state → new `compat.remove_all_children()`.
- The `Gtk.SearchEntry` placeholder fallback set a GObject property that itself is 4.10+, raising `TypeError` on exactly the versions it targeted (**Quarantine view crashed on first open**) → new `compat.safe_set_placeholder_text()`.
- Unguarded `Adw.ActionRow.set_subtitle_lines()` (libadwaita 1.2+) in the scan view → routed through `safe_set_subtitle_lines()`.

### Core fixes
- **Scan output corruption**: the streaming reader re-appended the trailing partial line in the process-exit drain path, corrupting the text that result parsing runs over (wrong scan statistics / garbled infected-file paths on progress-enabled scans). Regression tests added.
- **systemd detection**: `systemctl is-active` prints "inactive" for units that don't exist; this made the updater short-circuit before probing openSUSE's `freshclam.service` (UI updates permanently failed there) and misreported machines with no clamd as "installed but not active". New `systemd_unit_exists()` confirms via `LoadState`.
- **Quarantine short writes**: `os.write()` return values were unchecked in the copy loops; a short write (disk full) produced a truncated quarantine file whose SHA-256 never verifies — after the source was already unlinked. Writes now loop to completion.
- `glob_to_regex()` treated an escaped trailing `$` as the end anchor, silently widening exclusions like `backup$` to prefix matches (under-scanning).
- `clamui status` now honors `scan_backend`/`clamd_conf_path` settings; `clamui help install-privileged-helper` no longer reports "Unknown command".

### UX improvements
- **Quarantine Delete/Restore now confirm** — Delete was a one-click permanent deletion with no undo; Restore silently put a detected threat back on disk.
- **Escape closes all 15 dialogs** (GNOME HIG) via a shared `enable_escape_to_close()` helper — Adw.Window doesn't bind Escape by default, so no dialog in the app was keyboard-dismissable.
- Silent failures now report: profile import/export toasts, file-manager-integration dialog stays open when actions fail.
- Statistics timeframe toggles act as a radio group (could be fully deselected); minimize-to-tray no longer leaves the tray menu reading "Hide Window"; stale "Show N more" rows in results dialogs are removed; "Export" buttons that copy to clipboard are relabeled as copy actions; freshclam status no longer sticks on "Checking…" if you switch views during the check; tray subprocess respawns no longer leak pipe fds.
- Latent bugs fixed in the not-yet-wired `src/ui/scan/` package: construction-order crash, completion delivered before the state change (tray showed "protected" right after threats were found), `show_live_progress` half-honored, live threat-count title undercounting, path ellipsizing/a11y on target rows.

### i18n
- ~30 user-facing strings that bypassed gettext are now translatable (logs view export/copy messages — plural-aware via `ngettext` — debug page dialogs, pagination labels, file chooser buttons, components-view setup notes that concatenated `N_()` results at module level and could never match the catalog).
- `POTFILES.in` fixed (two missing files, one stale entry — the i18n workflow fails on `po/` changes otherwise) and `po/clamui.pot` regenerated.

### CI
- `dependency-audit.yml`: the `uv export` step used a plain YAML scalar, folding the backslash continuations into literal arguments — the job failed on every run. Now a block scalar.

## Test plan
- Full suite under xvfb: 4800+ passed; the only failures are pre-existing root-environment artifacts (permission-denied tests can't fail when running as root) that fail identically on `master`.
- `ruff check` + `ruff format --check` clean; `check-potfiles.sh` and `check-translations.sh` pass.
- New regression tests: scanner stream partial-line handling, glob `$` anchoring, systemd unit-existence detection, quarantine confirmation flow, prefs collect-data guards.

## Known issues intentionally not addressed (follow-ups)
- `src/ui/scan/` package is still dead code (production uses monolithic `scan_view.py`); latent bugs fixed so it's ready to wire in.
- "Preset Exclusions (Auto-Saved)" switches are decorative — never persisted nor applied to scans.
- `ProfileManager`/`SettingsManager` both rewrite `settings.json` whole (lost-update risk); `DeviceMonitor` cancels scanners synchronously on the GTK main thread (UI freeze up to ~7 s on USB unplug mid-scan); newline-containing filenames bypass daemon file-list scans; VirusTotal uploads buffer up to 650 MB in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GA2fMGtpSWuFcUjb1r8L3o