### PR TITLE
fix(core): sanitize env for all host helpers spawned from AppImage builds

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@
 src/app.py
 src/main.py
 src/cli/help_cmd.py
+src/cli/install_helper.py
 src/cli/history_cmd.py
 src/cli/profile_cmd.py
 src/cli/quarantine_cmd.py
@@ -12,13 +13,13 @@ src/cli/scan_cmd.py
 src/cli/scheduled_scan.py
 src/cli/status_cmd.py
 src/notification_dispatcher.py
+src/core/clamav_config.py
 src/core/clamav_detection.py
 src/core/system_audit.py
 src/core/file_manager_integration.py
 src/core/keyring_manager.py
 src/core/device_monitor.py
 src/core/notification_manager.py
-src/core/portmaster_client.py
 src/core/quarantine/manager.py
 src/core/result_formatters.py
 src/core/scanner_base.py

--- a/po/clamui.pot
+++ b/po/clamui.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ClamUI 0.2.0\n"
+"Project-Id-Version: ClamUI 0.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linx-systems/clamui/issues\n"
-"POT-Creation-Date: 2026-06-09 19:59+0200\n"
+"POT-Creation-Date: 2026-07-01 22:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,22 @@ msgstr[1] ""
 msgid "Select File or Folder"
 msgstr ""
 
-#: src/cli/help_cmd.py:23 src/cli/scan_cmd.py:33
+#: src/app.py:894
+msgid "A scan is already running — the new scan request was ignored"
+msgstr ""
+
+#: src/app.py:915
+#, python-brace-format
+msgid ""
+"VirusTotal scans one file per request — {count} additional selection was "
+"ignored"
+msgid_plural ""
+"VirusTotal scans one file per request — {count} additional selections were "
+"ignored"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/cli/help_cmd.py:23 src/cli/scan_cmd.py:34
 msgid "Scan files or directories for threats"
 msgstr ""
 
@@ -137,6 +152,51 @@ msgid ""
 "Run 'clamui {name} --help' for full option reference."
 msgstr ""
 
+#: src/cli/install_helper.py:88
+#, python-brace-format
+msgid "Required source file not found: {path}"
+msgstr ""
+
+#: src/cli/install_helper.py:98
+msgid "Unexpected relative import remains in the helper source; aborting."
+msgstr ""
+
+#: src/cli/install_helper.py:126
+#, python-brace-format
+msgid "Failed to install privileged helper: {error}"
+msgstr ""
+
+#: src/cli/install_helper.py:131
+#, python-brace-format
+msgid ""
+"Installed privileged helper at {bin} and polkit policy at {policy}. Saving "
+"system ClamAV configuration from ClamUI should now work."
+msgstr ""
+
+#: src/cli/install_helper.py:145
+msgid ""
+"This command installs files under /usr and /usr/share and must be run as "
+"root. Try: sudo clamui install-privileged-helper"
+msgstr ""
+
+#: src/cli/install_helper.py:157 src/core/result_formatters.py:167
+#: src/ui/update_view.py:678
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: src/cli/install_helper.py:165
+msgid "Install the privileged config helper and polkit policy (run with sudo)"
+msgstr ""
+
+#: src/cli/install_helper.py:167
+msgid ""
+"Install /usr/bin/clamui-apply-preferences and its polkit policy so ClamUI "
+"can save system ClamAV configuration. Run as root (sudo). Needed for "
+"AppImage, Flatpak, and pip installs; the Debian package installs these "
+"automatically."
+msgstr ""
+
 #: src/cli/history_cmd.py:26 src/cli/history_cmd.py:28
 msgid "--limit must be a positive integer"
 msgstr ""
@@ -181,7 +241,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: src/cli/history_cmd.py:88 src/core/result_formatters.py:87
+#: src/cli/history_cmd.py:88 src/core/result_formatters.py:130
 msgid "Summary"
 msgstr ""
 
@@ -269,7 +329,7 @@ msgid ""
 msgstr ""
 
 #: src/cli/profile_cmd.py:122 src/cli/profile_cmd.py:176
-#: src/cli/scan_cmd.py:113
+#: src/cli/scan_cmd.py:114
 #, python-brace-format
 msgid "Profile not found: {name}"
 msgstr ""
@@ -434,97 +494,97 @@ msgstr ""
 msgid "commands"
 msgstr ""
 
-#: src/cli/scan_cmd.py:35
+#: src/cli/scan_cmd.py:36
 msgid ""
 "Scan one or more files or directories with ClamAV.\n"
 "Exit codes: 0 = clean, 1 = threats found, 2 = error."
 msgstr ""
 
-#: src/cli/scan_cmd.py:44
+#: src/cli/scan_cmd.py:45
 msgid "Files or directories to scan"
 msgstr ""
 
-#: src/cli/scan_cmd.py:50
+#: src/cli/scan_cmd.py:51
 msgid "Do not scan directories recursively"
 msgstr ""
 
-#: src/cli/scan_cmd.py:56
+#: src/cli/scan_cmd.py:57
 msgid "Use a named scan profile for exclusions"
 msgstr ""
 
-#: src/cli/scan_cmd.py:62 src/cli/scheduled_scan.py:127
+#: src/cli/scan_cmd.py:63 src/cli/scheduled_scan.py:127
 #: src/ui/preferences/scheduled_page.py:182
 msgid "Automatically quarantine detected threats"
 msgstr ""
 
-#: src/cli/scan_cmd.py:68
+#: src/cli/scan_cmd.py:69
 msgid "Output results as JSON"
 msgstr ""
 
-#: src/cli/scan_cmd.py:74 src/cli/scheduled_scan.py:144
+#: src/cli/scan_cmd.py:75 src/cli/scheduled_scan.py:144
 msgid "Enable verbose output"
 msgstr ""
 
-#: src/cli/scan_cmd.py:95
+#: src/cli/scan_cmd.py:96
 #, python-brace-format
 msgid "Path not found: {path}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:116
+#: src/cli/scan_cmd.py:117
 #, python-brace-format
 msgid "Using profile: {name}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:144
+#: src/cli/scan_cmd.py:145
 #, python-brace-format
 msgid "Scanning: {path}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:227
+#: src/cli/scan_cmd.py:228
 #, python-brace-format
 msgid "Scanned {count} files in {duration:.1f}s"
 msgstr ""
 
-#: src/cli/scan_cmd.py:231
+#: src/cli/scan_cmd.py:232
 #, python-brace-format
 msgid ""
 "\n"
 "Threats found: {count}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:238
+#: src/cli/scan_cmd.py:239
 #, python-brace-format
 msgid ""
 "\n"
 "Quarantined: {count} file(s)"
 msgstr ""
 
-#: src/cli/scan_cmd.py:240
+#: src/cli/scan_cmd.py:241
 msgid ""
 "\n"
 "Failed to quarantine:"
 msgstr ""
 
-#: src/cli/scan_cmd.py:244
+#: src/cli/scan_cmd.py:245
 msgid ""
 "\n"
 "Scan completed with errors:"
 msgstr ""
 
-#: src/cli/scan_cmd.py:249
+#: src/cli/scan_cmd.py:250
 msgid "No threats found."
 msgstr ""
 
-#: src/cli/scan_cmd.py:265
+#: src/cli/scan_cmd.py:266
 msgid "No valid paths to scan"
 msgstr ""
 
-#: src/cli/scan_cmd.py:273
+#: src/cli/scan_cmd.py:275
 #, python-brace-format
 msgid "ClamAV not available: {error}"
 msgstr ""
 
-#: src/cli/scan_cmd.py:276 src/cli/scheduled_scan.py:323
+#: src/cli/scan_cmd.py:278 src/cli/scheduled_scan.py:323
 #, python-brace-format
 msgid "ClamAV version: {version}"
 msgstr ""
@@ -693,12 +753,12 @@ msgstr ""
 msgid "Scan Duration: {duration:.1f} seconds"
 msgstr ""
 
-#: src/cli/scheduled_scan.py:503 src/core/result_formatters.py:89
+#: src/cli/scheduled_scan.py:503 src/core/result_formatters.py:132
 #, python-brace-format
 msgid "Files Scanned: {count}"
 msgstr ""
 
-#: src/cli/scheduled_scan.py:504 src/core/result_formatters.py:91
+#: src/cli/scheduled_scan.py:504 src/core/result_formatters.py:134
 #, python-brace-format
 msgid "Threats Found: {count}"
 msgstr ""
@@ -845,8 +905,8 @@ msgstr ""
 msgid "Scanned {count} files. System appears clean."
 msgstr ""
 
-#: src/notification_dispatcher.py:41 src/core/result_formatters.py:128
-#: src/ui/scan_results_dialog.py:207
+#: src/notification_dispatcher.py:41 src/core/result_formatters.py:171
+#: src/ui/scan_results_dialog.py:215
 msgid "Scan Cancelled"
 msgstr ""
 
@@ -854,8 +914,8 @@ msgstr ""
 msgid "The scan was cancelled by the user."
 msgstr ""
 
-#: src/notification_dispatcher.py:44 src/core/result_formatters.py:120
-#: src/ui/scan_results_dialog.py:222 src/ui/virustotal_results_dialog.py:196
+#: src/notification_dispatcher.py:44 src/core/result_formatters.py:163
+#: src/ui/scan_results_dialog.py:230 src/ui/virustotal_results_dialog.py:196
 msgid "Scan Error"
 msgstr ""
 
@@ -901,6 +961,44 @@ msgstr ""
 msgid "No threats detected by VirusTotal"
 msgstr ""
 
+#: src/core/clamav_config.py:1051
+msgid ""
+"ClamUI privileged helper not installed. Install the 'clamui' package on your "
+"host system to apply settings."
+msgstr ""
+
+#: src/core/clamav_config.py:1095
+msgid ""
+"The staging directory is not reachable by the privileged helper running on "
+"the host, so preferences cannot be applied from the Flatpak sandbox. A host-"
+"side ClamUI install is required to change system configuration."
+msgstr ""
+
+#: src/core/clamav_config.py:1109
+msgid "Authentication was canceled. Configuration changes were not applied."
+msgstr ""
+
+#: src/core/clamav_config.py:1115
+msgid ""
+"Could not obtain administrator authorization to apply these changes. If you "
+"were not shown a password prompt, the ClamUI polkit policy or privileged "
+"helper is likely not installed on this system -- install the ClamUI system "
+"package (which provides clamui-apply-preferences and its polkit policy) to "
+"enable saving system configuration."
+msgstr ""
+
+#: src/core/clamav_config.py:1127
+msgid ""
+"Privileged helper rejected the request: missing PKEXEC_UID. The polkit "
+"policy may be misconfigured."
+msgstr ""
+
+#: src/core/clamav_config.py:1135
+msgid ""
+"Privileged helper rejected the request: protocol mismatch. Update the "
+"'clamui' package on the host."
+msgstr ""
+
 #: src/core/clamav_detection.py:47
 msgid ""
 "ClamAV is not installed. Please install it with: sudo apt install clamav"
@@ -943,7 +1041,7 @@ msgstr ""
 msgid "freshclam check timed out"
 msgstr ""
 
-#: src/core/clamav_detection.py:125 src/core/updater.py:555
+#: src/core/clamav_detection.py:125 src/core/updater.py:561
 msgid "freshclam executable not found"
 msgstr ""
 
@@ -1038,7 +1136,7 @@ msgstr ""
 msgid "Timed out checking host database directory: {path}"
 msgstr ""
 
-#: src/core/clamav_detection.py:388 src/core/system_audit.py:264
+#: src/core/clamav_detection.py:388 src/core/system_audit.py:265
 msgid "flatpak-spawn not available"
 msgstr ""
 
@@ -1068,663 +1166,663 @@ msgid ""
 "freshclam. Details: {detail}"
 msgstr ""
 
-#: src/core/system_audit.py:262
+#: src/core/system_audit.py:263
 msgid "Timed out reading database"
 msgstr ""
 
-#: src/core/system_audit.py:268 src/core/system_audit.py:277
+#: src/core/system_audit.py:269 src/core/system_audit.py:278
 msgid "Permission denied reading database"
 msgstr ""
 
-#: src/core/system_audit.py:275
+#: src/core/system_audit.py:276
 msgid "Database file not found"
 msgstr ""
 
-#: src/core/system_audit.py:297
+#: src/core/system_audit.py:298
 msgid "Invalid database file format"
 msgstr ""
 
-#: src/core/system_audit.py:307
+#: src/core/system_audit.py:314
 msgid "Could not parse database timestamp"
 msgstr ""
 
-#: src/core/system_audit.py:427 src/ui/audit_view.py:194
+#: src/core/system_audit.py:434 src/ui/audit_view.py:194
 msgid "ClamAV Health"
 msgstr ""
 
-#: src/core/system_audit.py:436 src/core/system_audit.py:445
+#: src/core/system_audit.py:443 src/core/system_audit.py:452
 msgid "ClamAV Installation"
 msgstr ""
 
-#: src/core/system_audit.py:438
+#: src/core/system_audit.py:445
 #, python-brace-format
 msgid "Installed: {version}"
 msgstr ""
 
-#: src/core/system_audit.py:447
+#: src/core/system_audit.py:454
 msgid "ClamAV is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:448
+#: src/core/system_audit.py:455
 msgid "Install ClamAV to enable virus scanning"
 msgstr ""
 
-#: src/core/system_audit.py:464 src/core/system_audit.py:475
-#: src/core/system_audit.py:488 src/core/system_audit.py:503
-#: src/core/system_audit.py:516 src/core/system_audit.py:527
+#: src/core/system_audit.py:471 src/core/system_audit.py:482
+#: src/core/system_audit.py:495 src/core/system_audit.py:510
+#: src/core/system_audit.py:523 src/core/system_audit.py:534
 msgid "Virus Database"
 msgstr ""
 
-#: src/core/system_audit.py:466
+#: src/core/system_audit.py:473
 #, python-brace-format
 msgid "Up to date ({days} days old, built {date})"
 msgstr ""
 
-#: src/core/system_audit.py:477 src/core/system_audit.py:490
+#: src/core/system_audit.py:484 src/core/system_audit.py:497
 #, python-brace-format
 msgid "Database is {days} days old (built {date})"
 msgstr ""
 
-#: src/core/system_audit.py:480
+#: src/core/system_audit.py:487
 msgid "Update virus database to ensure protection"
 msgstr ""
 
-#: src/core/system_audit.py:493
+#: src/core/system_audit.py:500
 msgid "Database is critically outdated. Update immediately."
 msgstr ""
 
-#: src/core/system_audit.py:505
+#: src/core/system_audit.py:512
 #, python-brace-format
 msgid "Database built {date} (age could not be determined)"
 msgstr ""
 
-#: src/core/system_audit.py:518
+#: src/core/system_audit.py:525
 msgid "No virus database found"
 msgstr ""
 
-#: src/core/system_audit.py:519
+#: src/core/system_audit.py:526
 msgid "Download virus database"
 msgstr ""
 
-#: src/core/system_audit.py:529
+#: src/core/system_audit.py:536
 msgid "Database files exist but age could not be determined"
 msgstr ""
 
-#: src/core/system_audit.py:540 src/core/system_audit.py:553
-#: src/core/system_audit.py:562 src/ui/logs_view.py:266
+#: src/core/system_audit.py:547 src/core/system_audit.py:560
+#: src/core/system_audit.py:569 src/ui/logs_view.py:272
 msgid "ClamAV Daemon"
 msgstr ""
 
-#: src/core/system_audit.py:542
+#: src/core/system_audit.py:549
 #, python-brace-format
 msgid "Service {name} is running"
 msgstr ""
 
-#: src/core/system_audit.py:555
+#: src/core/system_audit.py:562
 msgid "Daemon is responding"
 msgstr ""
 
-#: src/core/system_audit.py:564
+#: src/core/system_audit.py:571
 msgid "ClamAV daemon is not running"
 msgstr ""
 
-#: src/core/system_audit.py:565
+#: src/core/system_audit.py:572
 msgid "Start the daemon for faster scanning"
 msgstr ""
 
-#: src/core/system_audit.py:577 src/core/system_audit.py:587
-#: src/core/system_audit.py:950 src/core/system_audit.py:1020
+#: src/core/system_audit.py:584 src/core/system_audit.py:594
+#: src/core/system_audit.py:957 src/core/system_audit.py:1027
 #: src/ui/audit_view.py:203
 msgid "Automatic Updates"
 msgstr ""
 
-#: src/core/system_audit.py:579
+#: src/core/system_audit.py:586
 msgid "Freshclam service is active"
 msgstr ""
 
-#: src/core/system_audit.py:589
+#: src/core/system_audit.py:596
 msgid "Freshclam automatic update service is not running"
 msgstr ""
 
-#: src/core/system_audit.py:590
+#: src/core/system_audit.py:597
 msgid "Enable automatic database updates"
 msgstr ""
 
-#: src/core/system_audit.py:603 src/core/system_audit.py:681
+#: src/core/system_audit.py:610 src/core/system_audit.py:688
 #: src/ui/audit_view.py:195
 msgid "Firewall"
 msgstr ""
 
-#: src/core/system_audit.py:618 src/core/system_audit.py:628
+#: src/core/system_audit.py:625 src/core/system_audit.py:635
 msgid "UFW Firewall"
 msgstr ""
 
-#: src/core/system_audit.py:620
+#: src/core/system_audit.py:627
 msgid "UFW is active and enabled"
 msgstr ""
 
-#: src/core/system_audit.py:630
+#: src/core/system_audit.py:637
 msgid "UFW service is running but firewall may be disabled"
 msgstr ""
 
-#: src/core/system_audit.py:631
+#: src/core/system_audit.py:638
 msgid "Enable the firewall"
 msgstr ""
 
-#: src/core/system_audit.py:644 src/core/system_audit.py:654
+#: src/core/system_audit.py:651 src/core/system_audit.py:661
 msgid "Firewalld"
 msgstr ""
 
-#: src/core/system_audit.py:646
+#: src/core/system_audit.py:653
 msgid "Firewalld is running"
 msgstr ""
 
-#: src/core/system_audit.py:656
+#: src/core/system_audit.py:663
 msgid "Firewalld is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:657
+#: src/core/system_audit.py:664
 msgid "Start the firewall"
 msgstr ""
 
-#: src/core/system_audit.py:670
+#: src/core/system_audit.py:677
 msgid "nftables"
 msgstr ""
 
-#: src/core/system_audit.py:672
+#: src/core/system_audit.py:679
 msgid "nftables service is active"
 msgstr ""
 
-#: src/core/system_audit.py:683
+#: src/core/system_audit.py:690
 msgid "No active firewall detected"
 msgstr ""
 
-#: src/core/system_audit.py:684
+#: src/core/system_audit.py:691
 msgid "Install and enable a firewall for network protection"
 msgstr ""
 
-#: src/core/system_audit.py:712 src/core/system_audit.py:724
+#: src/core/system_audit.py:719 src/core/system_audit.py:731
 msgid "Firewall Manager"
 msgstr ""
 
-#: src/core/system_audit.py:714
+#: src/core/system_audit.py:721
 #, python-brace-format
 msgid "{name} is available"
 msgstr ""
 
-#: src/core/system_audit.py:716
+#: src/core/system_audit.py:723
 #, python-brace-format
 msgid "Open {name}"
 msgstr ""
 
-#: src/core/system_audit.py:726
+#: src/core/system_audit.py:733
 msgid "No graphical firewall manager detected"
 msgstr ""
 
-#: src/core/system_audit.py:727
+#: src/core/system_audit.py:734
 msgid "Install a GUI for easier firewall management"
 msgstr ""
 
-#: src/core/system_audit.py:814 src/core/system_audit.py:826
-#: src/core/system_audit.py:836
+#: src/core/system_audit.py:821 src/core/system_audit.py:833
+#: src/core/system_audit.py:843
 msgid "Open Ports"
 msgstr ""
 
-#: src/core/system_audit.py:816
+#: src/core/system_audit.py:823
 #, python-brace-format
 msgid "{count} ports listening, risky ports: {ports}"
 msgstr ""
 
-#: src/core/system_audit.py:819
+#: src/core/system_audit.py:826
 msgid "Review if these services need to be exposed"
 msgstr ""
 
-#: src/core/system_audit.py:828
+#: src/core/system_audit.py:835
 #, python-brace-format
 msgid "{count} ports listening"
 msgstr ""
 
-#: src/core/system_audit.py:829
+#: src/core/system_audit.py:836
 msgid "Review open ports and close unnecessary services"
 msgstr ""
 
-#: src/core/system_audit.py:838
+#: src/core/system_audit.py:845
 msgid "No open ports detected"
 msgstr ""
 
-#: src/core/system_audit.py:848 src/ui/audit_view.py:198
+#: src/core/system_audit.py:855 src/ui/audit_view.py:198
 msgid "Access Control"
 msgstr ""
 
-#: src/core/system_audit.py:869
+#: src/core/system_audit.py:876
 msgid "MAC Framework"
 msgstr ""
 
-#: src/core/system_audit.py:871
+#: src/core/system_audit.py:878
 msgid "No mandatory access control framework detected"
 msgstr ""
 
-#: src/core/system_audit.py:872
+#: src/core/system_audit.py:879
 msgid "Consider enabling AppArmor or SELinux"
 msgstr ""
 
-#: src/core/system_audit.py:896 src/core/system_audit.py:903
+#: src/core/system_audit.py:903 src/core/system_audit.py:910
 msgid "AppArmor"
 msgstr ""
 
-#: src/core/system_audit.py:898
+#: src/core/system_audit.py:905
 msgid "AppArmor is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:905
+#: src/core/system_audit.py:912
 msgid "AppArmor module is loaded but not enabled"
 msgstr ""
 
-#: src/core/system_audit.py:906
+#: src/core/system_audit.py:913
 msgid "Enable AppArmor for application sandboxing"
 msgstr ""
 
-#: src/core/system_audit.py:922 src/core/system_audit.py:929
-#: src/core/system_audit.py:937
+#: src/core/system_audit.py:929 src/core/system_audit.py:936
+#: src/core/system_audit.py:944
 msgid "SELinux"
 msgstr ""
 
-#: src/core/system_audit.py:924
+#: src/core/system_audit.py:931
 msgid "SELinux is enforcing"
 msgstr ""
 
-#: src/core/system_audit.py:931
+#: src/core/system_audit.py:938
 msgid "SELinux is in permissive mode"
 msgstr ""
 
-#: src/core/system_audit.py:932
+#: src/core/system_audit.py:939
 msgid "Consider switching to enforcing mode for stronger protection"
 msgstr ""
 
-#: src/core/system_audit.py:939
+#: src/core/system_audit.py:946
 msgid "SELinux is disabled"
 msgstr ""
 
-#: src/core/system_audit.py:940
+#: src/core/system_audit.py:947
 msgid "Enable SELinux for mandatory access control"
 msgstr ""
 
-#: src/core/system_audit.py:963 src/core/system_audit.py:973
+#: src/core/system_audit.py:970 src/core/system_audit.py:980
 msgid "Unattended Upgrades"
 msgstr ""
 
-#: src/core/system_audit.py:965
+#: src/core/system_audit.py:972
 msgid "Automatic security updates are enabled"
 msgstr ""
 
-#: src/core/system_audit.py:975
+#: src/core/system_audit.py:982
 msgid "Unattended upgrades is installed but disabled"
 msgstr ""
 
-#: src/core/system_audit.py:976
+#: src/core/system_audit.py:983
 msgid "Enable automatic security updates"
 msgstr ""
 
-#: src/core/system_audit.py:989 src/core/system_audit.py:1000
+#: src/core/system_audit.py:996 src/core/system_audit.py:1007
 msgid "DNF Automatic"
 msgstr ""
 
-#: src/core/system_audit.py:991
+#: src/core/system_audit.py:998
 msgid "DNF automatic updates are enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1002
+#: src/core/system_audit.py:1009
 msgid "DNF automatic is installed but timer is not active"
 msgstr ""
 
-#: src/core/system_audit.py:1003
+#: src/core/system_audit.py:1010
 msgid "Enable automatic updates"
 msgstr ""
 
-#: src/core/system_audit.py:1022
+#: src/core/system_audit.py:1029
 msgid "Could not determine automatic update status"
 msgstr ""
 
-#: src/core/system_audit.py:1023
+#: src/core/system_audit.py:1030
 msgid "Configure automatic security updates"
 msgstr ""
 
-#: src/core/system_audit.py:1046
+#: src/core/system_audit.py:1053
 msgid "Pending Reboot"
 msgstr ""
 
-#: src/core/system_audit.py:1048
+#: src/core/system_audit.py:1055
 msgid "System reboot required to apply updates"
 msgstr ""
 
-#: src/core/system_audit.py:1049
+#: src/core/system_audit.py:1056
 msgid "Reboot the system to apply pending security updates"
 msgstr ""
 
-#: src/core/system_audit.py:1058 src/ui/audit_view.py:208
+#: src/core/system_audit.py:1065 src/ui/audit_view.py:208
 msgid "Intrusion Detection"
 msgstr ""
 
-#: src/core/system_audit.py:1069 src/core/system_audit.py:1080
+#: src/core/system_audit.py:1076 src/core/system_audit.py:1087
 msgid "fail2ban"
 msgstr ""
 
-#: src/core/system_audit.py:1071
+#: src/core/system_audit.py:1078
 msgid "fail2ban is active and protecting services"
 msgstr ""
 
-#: src/core/system_audit.py:1082
+#: src/core/system_audit.py:1089
 msgid "fail2ban is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1083
+#: src/core/system_audit.py:1090
 msgid "Start fail2ban to protect against brute force attacks"
 msgstr ""
 
-#: src/core/system_audit.py:1095 src/core/system_audit.py:1106
+#: src/core/system_audit.py:1102 src/core/system_audit.py:1113
 msgid "CrowdSec"
 msgstr ""
 
-#: src/core/system_audit.py:1097
+#: src/core/system_audit.py:1104
 msgid "CrowdSec is active with community threat intelligence"
 msgstr ""
 
-#: src/core/system_audit.py:1108
+#: src/core/system_audit.py:1115
 msgid "CrowdSec is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1109
+#: src/core/system_audit.py:1116
 msgid "Start CrowdSec for collaborative intrusion prevention"
 msgstr ""
 
-#: src/core/system_audit.py:1125
+#: src/core/system_audit.py:1132
 msgid "Intrusion Prevention"
 msgstr ""
 
-#: src/core/system_audit.py:1127
+#: src/core/system_audit.py:1134
 msgid "No intrusion detection system found"
 msgstr ""
 
-#: src/core/system_audit.py:1128
+#: src/core/system_audit.py:1135
 msgid "Install fail2ban or CrowdSec to protect against attacks"
 msgstr ""
 
-#: src/core/system_audit.py:1141 src/ui/audit_view.py:211
+#: src/core/system_audit.py:1148 src/ui/audit_view.py:211
 msgid "SSH Security"
 msgstr ""
 
-#: src/core/system_audit.py:1156 src/core/system_audit.py:1166
+#: src/core/system_audit.py:1163 src/core/system_audit.py:1173
 msgid "SSH Server"
 msgstr ""
 
-#: src/core/system_audit.py:1158
+#: src/core/system_audit.py:1165
 msgid "SSH server is not running (no remote attack surface)"
 msgstr ""
 
-#: src/core/system_audit.py:1168
+#: src/core/system_audit.py:1175
 msgid "SSH server is running"
 msgstr ""
 
-#: src/core/system_audit.py:1178
+#: src/core/system_audit.py:1185
 msgid "SSH Configuration"
 msgstr ""
 
-#: src/core/system_audit.py:1180
+#: src/core/system_audit.py:1187
 msgid "Could not read SSH configuration"
 msgstr ""
 
-#: src/core/system_audit.py:1191 src/core/system_audit.py:1200
+#: src/core/system_audit.py:1198 src/core/system_audit.py:1207
 msgid "Root Login"
 msgstr ""
 
-#: src/core/system_audit.py:1193
+#: src/core/system_audit.py:1200
 #, python-brace-format
 msgid "Root login: {value}"
 msgstr ""
 
-#: src/core/system_audit.py:1202
+#: src/core/system_audit.py:1209
 #, python-brace-format
 msgid "Root login is allowed ({value})"
 msgstr ""
 
-#: src/core/system_audit.py:1203
+#: src/core/system_audit.py:1210
 msgid "Disable root SSH login for security"
 msgstr ""
 
-#: src/core/system_audit.py:1213 src/core/system_audit.py:1222
+#: src/core/system_audit.py:1220 src/core/system_audit.py:1229
 msgid "Password Auth"
 msgstr ""
 
-#: src/core/system_audit.py:1215
+#: src/core/system_audit.py:1222
 msgid "Password authentication is disabled (key-only)"
 msgstr ""
 
-#: src/core/system_audit.py:1224
+#: src/core/system_audit.py:1231
 msgid "Password authentication is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1225
+#: src/core/system_audit.py:1232
 msgid "Consider disabling password auth in favor of SSH keys"
 msgstr ""
 
-#: src/core/system_audit.py:1235 src/core/system_audit.py:1244
+#: src/core/system_audit.py:1242 src/core/system_audit.py:1251
 msgid "X11 Forwarding"
 msgstr ""
 
-#: src/core/system_audit.py:1237
+#: src/core/system_audit.py:1244
 msgid "X11 forwarding is disabled"
 msgstr ""
 
-#: src/core/system_audit.py:1246
+#: src/core/system_audit.py:1253
 msgid "X11 forwarding is enabled"
 msgstr ""
 
-#: src/core/system_audit.py:1247
+#: src/core/system_audit.py:1254
 msgid "Disable X11 forwarding to reduce attack surface"
 msgstr ""
 
-#: src/core/system_audit.py:1324 src/ui/audit_view.py:272
+#: src/core/system_audit.py:1331 src/ui/audit_view.py:272
 #: src/ui/audit_view.py:307
 msgid "Lynis Security Audit"
 msgstr ""
 
-#: src/core/system_audit.py:1333
+#: src/core/system_audit.py:1340
 msgid "Lynis"
 msgstr ""
 
-#: src/core/system_audit.py:1335
+#: src/core/system_audit.py:1342
 msgid "Lynis is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:1336
+#: src/core/system_audit.py:1343
 msgid "Install Lynis for comprehensive security auditing"
 msgstr ""
 
-#: src/core/system_audit.py:1364 src/core/system_audit.py:1374
-#: src/core/system_audit.py:1386 src/core/system_audit.py:1418
+#: src/core/system_audit.py:1371 src/core/system_audit.py:1381
+#: src/core/system_audit.py:1393 src/core/system_audit.py:1425
 msgid "Lynis Audit"
 msgstr ""
 
-#: src/core/system_audit.py:1366
+#: src/core/system_audit.py:1373
 msgid "Lynis audit timed out after 5 minutes"
 msgstr ""
 
-#: src/core/system_audit.py:1376
+#: src/core/system_audit.py:1383
 #, python-brace-format
 msgid "Failed to run Lynis: {error}"
 msgstr ""
 
-#: src/core/system_audit.py:1388 src/core/system_audit.py:1516
+#: src/core/system_audit.py:1395 src/core/system_audit.py:1523
 msgid "Authentication was cancelled"
 msgstr ""
 
-#: src/core/system_audit.py:1406
+#: src/core/system_audit.py:1413
 msgid "Hardening Index"
 msgstr ""
 
-#: src/core/system_audit.py:1408
+#: src/core/system_audit.py:1415
 #, python-brace-format
 msgid "Score: {score}/100"
 msgstr ""
 
-#: src/core/system_audit.py:1409
+#: src/core/system_audit.py:1416
 msgid "Run 'sudo lynis audit system' for detailed recommendations"
 msgstr ""
 
-#: src/core/system_audit.py:1420
+#: src/core/system_audit.py:1427
 #, python-brace-format
 msgid "Audit completed (exit code {code})"
 msgstr ""
 
-#: src/core/system_audit.py:1461 src/ui/audit_view.py:278
+#: src/core/system_audit.py:1468 src/ui/audit_view.py:278
 #: src/ui/audit_view.py:310
 msgid "Rootkit Detection"
 msgstr ""
 
-#: src/core/system_audit.py:1470
+#: src/core/system_audit.py:1477
 msgid "chkrootkit"
 msgstr ""
 
-#: src/core/system_audit.py:1472
+#: src/core/system_audit.py:1479
 msgid "chkrootkit is not installed"
 msgstr ""
 
-#: src/core/system_audit.py:1473
+#: src/core/system_audit.py:1480
 msgid "Install chkrootkit for rootkit detection"
 msgstr ""
 
-#: src/core/system_audit.py:1492 src/core/system_audit.py:1502
-#: src/core/system_audit.py:1514 src/core/system_audit.py:1534
-#: src/core/system_audit.py:1554 src/core/system_audit.py:1574
+#: src/core/system_audit.py:1499 src/core/system_audit.py:1509
+#: src/core/system_audit.py:1521 src/core/system_audit.py:1541
+#: src/core/system_audit.py:1561 src/core/system_audit.py:1581
 msgid "Rootkit Scan"
 msgstr ""
 
-#: src/core/system_audit.py:1494
+#: src/core/system_audit.py:1501
 msgid "Rootkit scan timed out after 5 minutes"
 msgstr ""
 
-#: src/core/system_audit.py:1504
+#: src/core/system_audit.py:1511
 #, python-brace-format
 msgid "Failed to run chkrootkit: {error}"
 msgstr ""
 
-#: src/core/system_audit.py:1527
+#: src/core/system_audit.py:1534
 #, python-brace-format
 msgid "Rootkit scan could not be completed (exit {code})"
 msgstr ""
 
-#: src/core/system_audit.py:1556
+#: src/core/system_audit.py:1563
 #, python-brace-format
 msgid "{count} potential rootkit(s) detected"
 msgstr ""
 
-#: src/core/system_audit.py:1557
+#: src/core/system_audit.py:1564
 msgid "Investigate the detected threats immediately"
 msgstr ""
 
-#: src/core/system_audit.py:1565
+#: src/core/system_audit.py:1572
 msgid "Finding"
 msgstr ""
 
-#: src/core/system_audit.py:1576
+#: src/core/system_audit.py:1583
 msgid "No rootkits detected"
 msgstr ""
 
-#: src/core/system_audit.py:1611 src/core/system_audit.py:1628
-#: src/core/system_audit.py:1663 src/core/system_audit.py:1674
-#: src/core/system_audit.py:1683 src/ui/audit_view.py:212
+#: src/core/system_audit.py:1618 src/core/system_audit.py:1635
+#: src/core/system_audit.py:1670 src/core/system_audit.py:1681
+#: src/core/system_audit.py:1690 src/ui/audit_view.py:212
 #: src/ui/audit_view.py:561
 msgid "Portmaster"
 msgstr ""
 
-#: src/core/system_audit.py:1630
+#: src/core/system_audit.py:1637
 msgid "Portmaster is running and protecting connections"
 msgstr ""
 
-#: src/core/system_audit.py:1652
+#: src/core/system_audit.py:1659
 msgid "Module Status"
 msgstr ""
 
-#: src/core/system_audit.py:1654
+#: src/core/system_audit.py:1661
 msgid "Authorize ClamUI in Portmaster for per-module health"
 msgstr ""
 
-#: src/core/system_audit.py:1656
+#: src/core/system_audit.py:1663
 msgid "Authorize"
 msgstr ""
 
-#: src/core/system_audit.py:1665
+#: src/core/system_audit.py:1672
 msgid "Portmaster is installed but not running"
 msgstr ""
 
-#: src/core/system_audit.py:1666
+#: src/core/system_audit.py:1673
 msgid "Start the Portmaster service to enable network protection"
 msgstr ""
 
-#: src/core/system_audit.py:1676
+#: src/core/system_audit.py:1683
 msgid "Not detected — optional network monitor and application firewall"
 msgstr ""
 
-#: src/core/system_audit.py:1685
+#: src/core/system_audit.py:1692
 #, python-brace-format
 msgid "Could not probe Portmaster: {error}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:371
+#: src/core/file_manager_integration.py:372
 msgid "Linux Mint / Cinnamon file manager"
 msgstr ""
 
-#: src/core/file_manager_integration.py:386
+#: src/core/file_manager_integration.py:387
 msgid "GNOME Files"
 msgstr ""
 
-#: src/core/file_manager_integration.py:401
+#: src/core/file_manager_integration.py:402
 msgid "KDE file manager"
 msgstr ""
 
-#: src/core/file_manager_integration.py:426
-#: src/core/file_manager_integration.py:511
+#: src/core/file_manager_integration.py:427
+#: src/core/file_manager_integration.py:512
 msgid "Not running as Flatpak"
 msgstr ""
 
-#: src/core/file_manager_integration.py:429
-#: src/core/file_manager_integration.py:514
+#: src/core/file_manager_integration.py:430
+#: src/core/file_manager_integration.py:515
 msgid "Integration files not found"
 msgstr ""
 
-#: src/core/file_manager_integration.py:440
-#: src/core/file_manager_integration.py:525
-#: src/core/file_manager_integration.py:600
+#: src/core/file_manager_integration.py:441
+#: src/core/file_manager_integration.py:526
+#: src/core/file_manager_integration.py:601
 #, python-brace-format
 msgid "Unknown file manager: {name}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:461
-#: src/core/file_manager_integration.py:465
-#: src/core/file_manager_integration.py:548
-#: src/core/file_manager_integration.py:552
+#: src/core/file_manager_integration.py:462
+#: src/core/file_manager_integration.py:466
+#: src/core/file_manager_integration.py:549
+#: src/core/file_manager_integration.py:553
 #, python-brace-format
 msgid "Invalid destination path: {path}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:481
-#: src/core/file_manager_integration.py:567
-#: src/core/file_manager_integration.py:616 src/core/updater.py:565
+#: src/core/file_manager_integration.py:482
+#: src/core/file_manager_integration.py:568
+#: src/core/file_manager_integration.py:617 src/core/updater.py:571
 #, python-brace-format
 msgid "Permission denied: {error}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:486
+#: src/core/file_manager_integration.py:487
 #, python-brace-format
 msgid "Failed to install integration: {error}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:572
+#: src/core/file_manager_integration.py:573
 #, python-brace-format
 msgid "Failed to repair integration: {error}"
 msgstr ""
 
-#: src/core/file_manager_integration.py:621
+#: src/core/file_manager_integration.py:622
 #, python-brace-format
 msgid "Failed to remove integration: {error}"
 msgstr ""
@@ -1794,7 +1892,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: src/core/notification_manager.py:87 src/core/notification_manager.py:175
-#: src/ui/scan_results_dialog.py:193
+#: src/ui/scan_results_dialog.py:201
 msgid "No threats found"
 msgstr ""
 
@@ -1958,267 +2056,297 @@ msgstr ""
 msgid "File integrity verification failed: {error}"
 msgstr ""
 
-#: src/core/result_formatters.py:78
+#: src/core/result_formatters.py:37 src/core/scanner_base.py:571
+#, python-brace-format
+msgid "{count} file(s) could not be accessed"
+msgstr ""
+
+#: src/core/result_formatters.py:55
+#, python-brace-format
+msgid "Scan complete - No threats found ({count} file(s) not accessible)"
+msgstr ""
+
+#: src/core/result_formatters.py:59
+#, python-brace-format
+msgid "Scan complete - No threats found ({warning})"
+msgstr ""
+
+#: src/core/result_formatters.py:62
+msgid "Scan complete - No threats found"
+msgstr ""
+
+#: src/core/result_formatters.py:121
 msgid "ClamUI Scan Report"
 msgstr ""
 
-#: src/core/result_formatters.py:80
+#: src/core/result_formatters.py:123
 #, python-brace-format
 msgid "Scan Date: {timestamp}"
 msgstr ""
 
-#: src/core/result_formatters.py:81
+#: src/core/result_formatters.py:124
 #, python-brace-format
 msgid "Scanned Path: {path}"
 msgstr ""
 
-#: src/core/result_formatters.py:82 src/ui/logs_view.py:773
+#: src/core/result_formatters.py:125 src/ui/logs_view.py:779
 #, python-brace-format
 msgid "Status: {status}"
 msgstr ""
 
-#: src/core/result_formatters.py:90
+#: src/core/result_formatters.py:133
 #, python-brace-format
 msgid "Directories Scanned: {count}"
 msgstr ""
 
-#: src/core/result_formatters.py:97 src/ui/scan_results_dialog.py:335
+#: src/core/result_formatters.py:140 src/ui/scan_results_dialog.py:343
 msgid "Detected Threats"
 msgstr ""
 
-#: src/core/result_formatters.py:104
+#: src/core/result_formatters.py:147
 #, python-brace-format
 msgid "[{index}] {severity} - {category}"
 msgstr ""
 
-#: src/core/result_formatters.py:108
+#: src/core/result_formatters.py:151
 #, python-brace-format
 msgid "    File: {path}"
 msgstr ""
 
-#: src/core/result_formatters.py:109
+#: src/core/result_formatters.py:152
 #, python-brace-format
 msgid "    Threat: {name}"
 msgstr ""
 
-#: src/core/result_formatters.py:113
+#: src/core/result_formatters.py:156
 msgid "No Threats Detected"
 msgstr ""
 
-#: src/core/result_formatters.py:116
+#: src/core/result_formatters.py:159
 msgid "All scanned files are clean."
 msgstr ""
 
-#: src/core/result_formatters.py:124 src/ui/update_view.py:678
-#, python-brace-format
-msgid "Error: {message}"
-msgstr ""
-
-#: src/core/result_formatters.py:131
+#: src/core/result_formatters.py:174
 msgid "The scan was cancelled before completion."
 msgstr ""
 
-#: src/core/result_formatters.py:175
+#: src/core/result_formatters.py:218
 msgid "File Path"
 msgstr ""
 
-#: src/core/result_formatters.py:175
+#: src/core/result_formatters.py:218
 msgid "Threat Name"
 msgstr ""
 
-#: src/core/result_formatters.py:175
+#: src/core/result_formatters.py:218
 msgid "Category"
 msgstr ""
 
-#: src/core/result_formatters.py:175
+#: src/core/result_formatters.py:218
 msgid "Severity"
 msgstr ""
 
-#: src/core/result_formatters.py:175
+#: src/core/result_formatters.py:218
 msgid "Timestamp"
 msgstr ""
 
-#: src/core/scanner_base.py:617
+#: src/core/scanner_base.py:569 src/core/scanner_base.py:586
+msgid "No files could be scanned"
+msgstr ""
+
+#: src/core/scanner_base.py:576
+#, python-brace-format
+msgid ""
+"{count} non-fatal warning(s) during scan; some files may have been only "
+"partially scanned"
+msgstr ""
+
+#: src/core/scanner_base.py:589
+#, python-brace-format
+msgid "{count} file(s) could not be read"
+msgstr ""
+
+#: src/core/scanner_base.py:763
 msgid "Scan cancelled by user"
 msgstr ""
 
-#: src/core/updater.py:234
+#: src/core/updater.py:236
 #, python-brace-format
 msgid "Freshclam service not running (status: {status})"
 msgstr ""
 
-#: src/core/updater.py:250
+#: src/core/updater.py:253
 msgid "Could not determine freshclam PID"
 msgstr ""
 
-#: src/core/updater.py:252
+#: src/core/updater.py:255
 #, python-brace-format
 msgid "Failed to get freshclam PID: {error}"
 msgstr ""
 
-#: src/core/updater.py:266 src/core/updater.py:286
+#: src/core/updater.py:270 src/core/updater.py:291
 #, python-brace-format
 msgid "Update signal sent to freshclam service (PID {pid})"
 msgstr ""
 
-#: src/core/updater.py:291 src/core/updater.py:301
+#: src/core/updater.py:296 src/core/updater.py:306
 #, python-brace-format
 msgid "Failed to send signal: {error}"
 msgstr ""
 
-#: src/core/updater.py:295
+#: src/core/updater.py:300
 msgid "Timeout sending elevated signal to freshclam"
 msgstr ""
 
-#: src/core/updater.py:304
+#: src/core/updater.py:309
 msgid "Timeout sending signal to freshclam"
 msgstr ""
 
-#: src/core/updater.py:306
+#: src/core/updater.py:311
 #, python-brace-format
 msgid "Error sending signal: {error}"
 msgstr ""
 
-#: src/core/updater.py:411
+#: src/core/updater.py:417
 msgid ""
 "Could not trigger freshclam service update. Try restarting the service: sudo "
 "systemctl restart clamav-freshclam"
 msgstr ""
 
-#: src/core/updater.py:445
+#: src/core/updater.py:451
 msgid "Delete failed"
 msgstr ""
 
-#: src/core/updater.py:464
+#: src/core/updater.py:470
 #, python-brace-format
 msgid ""
 "Another freshclam instance is running (PID {pid}). Stop it first: sudo "
 "systemctl stop clamav-freshclam"
 msgstr ""
 
-#: src/core/updater.py:575
+#: src/core/updater.py:581
 #, python-brace-format
 msgid "Update failed: {error}"
 msgstr ""
 
-#: src/core/updater.py:587
+#: src/core/updater.py:593
 msgid "Update timed out after 10 minutes"
 msgstr ""
 
-#: src/core/updater.py:600
+#: src/core/updater.py:606
 msgid "Update cancelled by user"
 msgstr ""
 
-#: src/core/updater.py:920 src/ui/update_view.py:657
+#: src/core/updater.py:926 src/ui/update_view.py:657
 #, python-brace-format
 msgid "{database} until {cooldown}"
 msgstr ""
 
-#: src/core/updater.py:957
+#: src/core/updater.py:963
 msgid ""
 "Authentication cancelled. Database update requires administrator privileges."
 msgstr ""
 
-#: src/core/updater.py:959
+#: src/core/updater.py:965
 msgid "Authorization failed. You are not authorized to update the database."
-msgstr ""
-
-#: src/core/updater.py:966
-#, python-brace-format
-msgid "Updated: {databases}"
 msgstr ""
 
 #: src/core/updater.py:972
 #, python-brace-format
+msgid "Updated: {databases}"
+msgstr ""
+
+#: src/core/updater.py:978
+#, python-brace-format
 msgid "Already current: {databases}"
 msgstr ""
 
-#: src/core/updater.py:979
+#: src/core/updater.py:985
 #, python-brace-format
 msgid ""
 "Database update partially completed. {progress}. Rate limited: {details}."
 msgstr ""
 
-#: src/core/updater.py:982
+#: src/core/updater.py:988
 #, python-brace-format
 msgid "Update rate limited for: {details}."
 msgstr ""
 
-#: src/core/updater.py:986
+#: src/core/updater.py:992
 msgid "Update rate limited by mirror. Please wait a few minutes and try again."
 msgstr ""
 
-#: src/core/updater.py:991
+#: src/core/updater.py:997
 msgid ""
 "Update blocked by CDN. This may be due to rate limiting. Please wait and try "
 "again later."
 msgstr ""
 
-#: src/core/updater.py:997
+#: src/core/updater.py:1003
 msgid "ClamAV mirror is currently unavailable. Please try again later."
 msgstr ""
 
-#: src/core/updater.py:1003
+#: src/core/updater.py:1009
 msgid "SSL/TLS certificate error. The mirror may have configuration issues."
 msgstr ""
 
-#: src/core/updater.py:1007
+#: src/core/updater.py:1013
 msgid "Connection timed out. Please check your network connection."
 msgstr ""
 
-#: src/core/updater.py:1011
+#: src/core/updater.py:1017
 msgid "Authorization failed. Please try again and enter your password."
 msgstr ""
 
-#: src/core/updater.py:1015
+#: src/core/updater.py:1021
 msgid "Database is locked. Another freshclam instance may be running."
 msgstr ""
 
-#: src/core/updater.py:1019
+#: src/core/updater.py:1025
 msgid ""
 "Permission denied. You may need elevated privileges to update the database."
 msgstr ""
 
-#: src/core/updater.py:1023
+#: src/core/updater.py:1029
 msgid "Connection error. Please check your network connection."
 msgstr ""
 
-#: src/core/updater.py:1027
+#: src/core/updater.py:1033
 msgid "DNS resolution failed. Please check your network settings."
 msgstr ""
 
-#: src/core/updater.py:1033
+#: src/core/updater.py:1039
 msgid "Update failed with an unknown error. Check the logs for details."
 msgstr ""
 
-#: src/core/updater.py:1045
+#: src/core/updater.py:1051
 #, python-brace-format
 msgid "Database update completed - {count} database(s) updated"
 msgstr ""
 
-#: src/core/updater.py:1049
+#: src/core/updater.py:1055
 msgid "Database update completed - Already up to date"
 msgstr ""
 
-#: src/core/updater.py:1051
+#: src/core/updater.py:1057
 msgid "Database update cancelled"
 msgstr ""
 
-#: src/core/updater.py:1053
+#: src/core/updater.py:1059
 #, python-brace-format
 msgid "Database update failed: {error}"
 msgstr ""
 
-#: src/core/updater.py:1054 src/ui/scan_results_dialog.py:224
-#: src/ui/scan_view.py:645 src/ui/scan_view.py:2263
+#: src/core/updater.py:1060 src/ui/scan_results_dialog.py:232
+#: src/ui/scan_view.py:646 src/ui/scan_view.py:2278
 #: src/ui/virustotal_results_dialog.py:197
 msgid "Unknown error"
 msgstr ""
 
 #: src/core/virustotal.py:262 src/core/virustotal.py:316
 #: src/core/virustotal.py:478 src/core/virustotal.py:621
-#: src/core/virustotal.py:629 src/ui/scan/scan_view.py:255
-#: src/ui/scan_view.py:2259
+#: src/core/virustotal.py:629 src/ui/scan/scan_view.py:257
+#: src/ui/scan_view.py:2274
 msgid "Scan cancelled"
 msgstr ""
 
@@ -2368,11 +2496,11 @@ msgid "Remember my choice"
 msgstr ""
 
 #: src/ui/close_behavior_dialog.py:153 src/ui/database_missing_dialog.py:132
-#: src/ui/file_manager_integration_dialog.py:261 src/ui/logs_view.py:100
+#: src/ui/file_manager_integration_dialog.py:261 src/ui/logs_view.py:102
 #: src/ui/preferences/virustotal_page.py:359 src/ui/profile_dialogs.py:121
 #: src/ui/profile_dialogs.py:721 src/ui/profile_dialogs.py:867
-#: src/ui/profile_dialogs.py:988 src/ui/scan/scan_view.py:168
-#: src/ui/scan_view.py:1260 src/ui/scan_view.py:1906 src/ui/update_view.py:145
+#: src/ui/profile_dialogs.py:988 src/ui/scan/scan_view.py:175
+#: src/ui/scan_view.py:1261 src/ui/scan_view.py:1907 src/ui/update_view.py:145
 msgid "Cancel"
 msgstr ""
 
@@ -2386,7 +2514,7 @@ msgstr ""
 
 #: src/ui/compat.py:426 src/ui/compat.py:492
 #: src/ui/preferences/database_page.py:336
-#: src/ui/preferences/scanner_page.py:239
+#: src/ui/preferences/scanner_page.py:240
 msgid "_Cancel"
 msgstr ""
 
@@ -2407,7 +2535,7 @@ msgid "Refresh Audit"
 msgstr ""
 
 #: src/ui/audit_view.py:236 src/ui/audit_view.py:789
-#: src/ui/components_view.py:239 src/ui/logs_view.py:509
+#: src/ui/components_view.py:239 src/ui/logs_view.py:515
 #: src/ui/statistics_view.py:185
 msgid "Checking..."
 msgstr ""
@@ -2467,7 +2595,7 @@ msgid "Open"
 msgstr ""
 
 #: src/ui/audit_view.py:657 src/ui/components_view.py:357
-#: src/ui/logs_view.py:389
+#: src/ui/logs_view.py:395
 msgid "Copy to clipboard"
 msgstr ""
 
@@ -2589,7 +2717,7 @@ msgstr ""
 msgid "Checking"
 msgstr ""
 
-#: src/ui/components_view.py:407 src/ui/preferences/scanner_page.py:342
+#: src/ui/components_view.py:407 src/ui/preferences/scanner_page.py:343
 msgid "Refresh Status"
 msgstr ""
 
@@ -2598,7 +2726,7 @@ msgid "Installed"
 msgstr ""
 
 #: src/ui/components_view.py:546 src/ui/components_view.py:597
-#: src/ui/logs_view.py:1249
+#: src/ui/logs_view.py:1268
 msgid "Not installed"
 msgstr ""
 
@@ -2606,7 +2734,7 @@ msgstr ""
 msgid "Not installed - expand for setup instructions"
 msgstr ""
 
-#: src/ui/components_view.py:579 src/ui/logs_view.py:1236
+#: src/ui/components_view.py:579 src/ui/logs_view.py:1255
 msgid "Running"
 msgstr ""
 
@@ -2614,7 +2742,7 @@ msgstr ""
 msgid "Daemon is running"
 msgstr ""
 
-#: src/ui/components_view.py:588 src/ui/logs_view.py:1243
+#: src/ui/components_view.py:588 src/ui/logs_view.py:1262
 msgid "Stopped"
 msgstr ""
 
@@ -2622,7 +2750,7 @@ msgstr ""
 msgid "Daemon is installed but not running"
 msgstr ""
 
-#: src/ui/components_view.py:605 src/ui/logs_view.py:1264
+#: src/ui/components_view.py:605 src/ui/logs_view.py:1283
 #: src/ui/quarantine_view.py:696 src/ui/statistics_view.py:190
 #: src/ui/statistics_view.py:806 src/ui/statistics_view.py:835
 msgid "Unknown"
@@ -2772,185 +2900,185 @@ msgstr ""
 msgid "No content to display"
 msgstr ""
 
-#: src/ui/logs_view.py:49
+#: src/ui/logs_view.py:51
 msgid "Clear All Logs?"
 msgstr ""
 
-#: src/ui/logs_view.py:51
+#: src/ui/logs_view.py:53
 msgid ""
 "This will permanently delete all historical logs. This action cannot be "
 "undone."
 msgstr ""
 
-#: src/ui/logs_view.py:105 src/ui/logs_view.py:288
+#: src/ui/logs_view.py:107 src/ui/logs_view.py:294
 #: src/ui/scan/target_selector.py:107
 msgid "Clear All"
 msgstr ""
 
-#: src/ui/logs_view.py:243 src/ui/logs_view.py:279
+#: src/ui/logs_view.py:249 src/ui/logs_view.py:285
 msgid "Historical Logs"
 msgstr ""
 
-#: src/ui/logs_view.py:280
+#: src/ui/logs_view.py:286
 msgid "Previous scan and update operations"
 msgstr ""
 
-#: src/ui/logs_view.py:296
+#: src/ui/logs_view.py:302
 msgid "Export all logs to JSON"
 msgstr ""
 
-#: src/ui/logs_view.py:305
+#: src/ui/logs_view.py:311
 msgid "Export all logs to CSV"
 msgstr ""
 
-#: src/ui/logs_view.py:314
+#: src/ui/logs_view.py:320
 msgid "Refresh logs"
 msgstr ""
 
-#: src/ui/logs_view.py:354
+#: src/ui/logs_view.py:360
 msgid "No logs yet"
 msgstr ""
 
-#: src/ui/logs_view.py:355
+#: src/ui/logs_view.py:361
 msgid "Logs from scans and updates will appear here"
 msgstr ""
 
-#: src/ui/logs_view.py:366
+#: src/ui/logs_view.py:372
 msgid "Loading logs..."
 msgstr ""
 
-#: src/ui/logs_view.py:377 src/ui/logs_view.py:854
+#: src/ui/logs_view.py:383 src/ui/logs_view.py:860
 msgid "Log Details"
 msgstr ""
 
-#: src/ui/logs_view.py:378
+#: src/ui/logs_view.py:384
 msgid "Select a log entry above to view details"
 msgstr ""
 
-#: src/ui/logs_view.py:398
+#: src/ui/logs_view.py:404
 msgid "Export to text file"
 msgstr ""
 
-#: src/ui/logs_view.py:407
+#: src/ui/logs_view.py:413
 msgid "Export to CSV file"
 msgstr ""
 
-#: src/ui/logs_view.py:416
+#: src/ui/logs_view.py:422
 msgid "Export to JSON file"
 msgstr ""
 
-#: src/ui/logs_view.py:425 src/ui/logs_view.py:497
+#: src/ui/logs_view.py:431 src/ui/logs_view.py:503
 msgid "View fullscreen"
 msgstr ""
 
-#: src/ui/logs_view.py:460 src/ui/logs_view.py:729 src/ui/logs_view.py:1179
+#: src/ui/logs_view.py:466 src/ui/logs_view.py:735 src/ui/logs_view.py:1185
 msgid "Select a log entry to view details."
 msgstr ""
 
-#: src/ui/logs_view.py:477
+#: src/ui/logs_view.py:483
 msgid "ClamAV Daemon Logs"
 msgstr ""
 
-#: src/ui/logs_view.py:478
+#: src/ui/logs_view.py:484
 msgid "Live logs from the clamd daemon"
 msgstr ""
 
-#: src/ui/logs_view.py:488
+#: src/ui/logs_view.py:494
 msgid "Export daemon logs to file"
 msgstr ""
 
-#: src/ui/logs_view.py:508 src/ui/preferences/scanner_page.py:322
+#: src/ui/logs_view.py:514 src/ui/preferences/scanner_page.py:323
 msgid "Daemon Status"
 msgstr ""
 
-#: src/ui/logs_view.py:515 src/ui/logs_view.py:1282
+#: src/ui/logs_view.py:521 src/ui/logs_view.py:1301
 msgid "Start live log updates"
 msgstr ""
 
-#: src/ui/logs_view.py:542
+#: src/ui/logs_view.py:548
 msgid "Daemon logs will appear here."
 msgstr ""
 
-#: src/ui/logs_view.py:544
+#: src/ui/logs_view.py:550
 msgid "Click the play button to start live updates."
 msgstr ""
 
-#: src/ui/logs_view.py:762
+#: src/ui/logs_view.py:768
 msgid "SCAN LOG"
 msgstr ""
 
-#: src/ui/logs_view.py:764
+#: src/ui/logs_view.py:770
 msgid "UPDATE LOG"
 msgstr ""
 
-#: src/ui/logs_view.py:770
+#: src/ui/logs_view.py:776
 #, python-brace-format
 msgid "ID: {id}"
 msgstr ""
 
-#: src/ui/logs_view.py:771
+#: src/ui/logs_view.py:777
 #, python-brace-format
 msgid "Timestamp: {timestamp}"
 msgstr ""
 
-#: src/ui/logs_view.py:772
+#: src/ui/logs_view.py:778
 #, python-brace-format
 msgid "Type: {type}"
 msgstr ""
 
-#: src/ui/logs_view.py:776 src/ui/quarantine_view.py:675
+#: src/ui/logs_view.py:782 src/ui/quarantine_view.py:675
 #, python-brace-format
 msgid "Path: {path}"
 msgstr ""
 
-#: src/ui/logs_view.py:779
+#: src/ui/logs_view.py:785
 #, python-brace-format
 msgid "Duration: {duration:.2f} seconds"
 msgstr ""
 
-#: src/ui/logs_view.py:793
+#: src/ui/logs_view.py:799
 msgid "Statistics Summary:"
 msgstr ""
 
-#: src/ui/logs_view.py:798
+#: src/ui/logs_view.py:804
 #, python-brace-format
 msgid "  Files Scanned: {count}"
 msgstr ""
 
-#: src/ui/logs_view.py:805
+#: src/ui/logs_view.py:811
 #, python-brace-format
 msgid "  Directories Scanned: {count}"
 msgstr ""
 
-#: src/ui/logs_view.py:814
+#: src/ui/logs_view.py:820
 #, python-brace-format
 msgid "{seconds:.2f} seconds"
 msgstr ""
 
-#: src/ui/logs_view.py:818
+#: src/ui/logs_view.py:824
 #, python-brace-format
 msgid "{minutes}m {seconds:.0f}s"
 msgstr ""
 
-#: src/ui/logs_view.py:824 src/ui/statistics_view.py:1030
+#: src/ui/logs_view.py:830 src/ui/statistics_view.py:1030
 #, python-brace-format
 msgid "{hours}h {minutes}m"
 msgstr ""
 
-#: src/ui/logs_view.py:825
+#: src/ui/logs_view.py:831
 #, python-brace-format
 msgid "  Duration: {duration}"
 msgstr ""
 
-#: src/ui/logs_view.py:830 src/ui/scan_view.py:665 src/ui/update_view.py:635
+#: src/ui/logs_view.py:836 src/ui/scan_view.py:666 src/ui/update_view.py:635
 msgid "Summary:"
 msgstr ""
 
-#: src/ui/logs_view.py:837
+#: src/ui/logs_view.py:843
 msgid "Full Output:"
 msgstr ""
 
-#: src/ui/logs_view.py:1258
+#: src/ui/logs_view.py:1277
 msgid ""
 "ClamAV daemon (clamd) is not installed.\n"
 "\n"
@@ -2958,7 +3086,7 @@ msgid ""
 "You can still use ClamUI for on-demand scanning without it."
 msgstr ""
 
-#: src/ui/logs_view.py:1277
+#: src/ui/logs_view.py:1296
 msgid "Stop live log updates"
 msgstr ""
 
@@ -3006,45 +3134,45 @@ msgstr ""
 msgid "The folder '{path}' does not exist."
 msgstr ""
 
-#: src/ui/preferences/base.py:573 src/ui/preferences/base.py:592
+#: src/ui/preferences/base.py:573 src/ui/preferences/base.py:593
 msgid "Error Opening Folder"
 msgstr ""
 
-#: src/ui/preferences/base.py:574 src/ui/preferences/base.py:593
+#: src/ui/preferences/base.py:574 src/ui/preferences/base.py:594
 #, python-brace-format
 msgid "Could not open folder: {error}"
 msgstr ""
 
-#: src/ui/preferences/base.py:643 src/ui/preferences/save_page.py:175
-#: src/ui/preferences/scanner_page.py:578
+#: src/ui/preferences/base.py:644 src/ui/preferences/save_page.py:175
+#: src/ui/preferences/scanner_page.py:580
 msgid "OK"
 msgstr ""
 
-#: src/ui/preferences/base.py:707
+#: src/ui/preferences/base.py:708
 msgid "File Location"
 msgstr ""
 
-#: src/ui/preferences/base.py:718
+#: src/ui/preferences/base.py:719
 msgid "Open Folder"
 msgstr ""
 
-#: src/ui/preferences/base.py:721
+#: src/ui/preferences/base.py:722
 msgid "Open containing folder in file manager"
 msgstr ""
 
-#: src/ui/preferences/base.py:742
+#: src/ui/preferences/base.py:743
 msgid "Detect"
 msgstr ""
 
-#: src/ui/preferences/base.py:745
+#: src/ui/preferences/base.py:746
 msgid "Auto-detect configuration file location"
 msgstr ""
 
-#: src/ui/preferences/base.py:752
+#: src/ui/preferences/base.py:753
 msgid "Browse"
 msgstr ""
 
-#: src/ui/preferences/base.py:755
+#: src/ui/preferences/base.py:756
 msgid "Browse for configuration file"
 msgstr ""
 
@@ -3168,7 +3296,7 @@ msgid "Database Updates"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:222
-#: src/ui/preferences/scanner_page.py:123
+#: src/ui/preferences/scanner_page.py:124
 #, python-brace-format
 msgid "Detected: {path}"
 msgstr ""
@@ -3178,7 +3306,7 @@ msgid "No freshclam.conf found in known locations"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:239
-#: src/ui/preferences/scanner_page.py:136
+#: src/ui/preferences/scanner_page.py:137
 msgid "Configuration File"
 msgstr ""
 
@@ -3187,25 +3315,25 @@ msgid "freshclam.conf location"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:277
-#: src/ui/preferences/scanner_page.py:178
+#: src/ui/preferences/scanner_page.py:179
 msgid "Configuration files"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:300
-#: src/ui/preferences/scanner_page.py:203
+#: src/ui/preferences/scanner_page.py:204
 #, python-brace-format
 msgid "Selected: {path}"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:313
 #: src/ui/preferences/database_page.py:332
-#: src/ui/preferences/scanner_page.py:216
-#: src/ui/preferences/scanner_page.py:235
+#: src/ui/preferences/scanner_page.py:217
+#: src/ui/preferences/scanner_page.py:236
 msgid "Select Configuration File"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:335
-#: src/ui/preferences/scanner_page.py:238
+#: src/ui/preferences/scanner_page.py:239
 msgid "_Select"
 msgstr ""
 
@@ -3230,7 +3358,7 @@ msgid "Notify ClamD Config"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:403
-#: src/ui/preferences/scanner_page.py:757
+#: src/ui/preferences/scanner_page.py:759
 msgid "Verbose Logging"
 msgstr ""
 
@@ -3239,12 +3367,12 @@ msgid "Enable detailed logging for database updates"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:410
-#: src/ui/preferences/scanner_page.py:764
+#: src/ui/preferences/scanner_page.py:766
 msgid "Syslog Logging"
 msgstr ""
 
 #: src/ui/preferences/database_page.py:411
-#: src/ui/preferences/scanner_page.py:765
+#: src/ui/preferences/scanner_page.py:767
 msgid "Send log messages to system log"
 msgstr ""
 
@@ -3724,7 +3852,7 @@ msgid "On Access"
 msgstr ""
 
 #: src/ui/preferences/onaccess_page.py:94
-#: src/ui/preferences/scanner_page.py:155
+#: src/ui/preferences/scanner_page.py:156
 msgid "Configuration Status"
 msgstr ""
 
@@ -3809,12 +3937,12 @@ msgid "Maximum number of scanning threads"
 msgstr ""
 
 #: src/ui/preferences/onaccess_page.py:230
-#: src/ui/preferences/scanner_page.py:679
+#: src/ui/preferences/scanner_page.py:681
 msgid "Max File Size (MB)"
 msgstr ""
 
 #: src/ui/preferences/onaccess_page.py:231
-#: src/ui/preferences/scanner_page.py:680
+#: src/ui/preferences/scanner_page.py:682
 msgid "Maximum file size to scan (0 = unlimited)"
 msgstr ""
 
@@ -3963,212 +4091,212 @@ msgstr ""
 msgid "Save Failed"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:95
+#: src/ui/preferences/scanner_page.py:96
 msgid "Scanner Settings"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:126
+#: src/ui/preferences/scanner_page.py:127
 msgid "No clamd.conf found in known locations"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:138
+#: src/ui/preferences/scanner_page.py:139
 msgid "clamd.conf location"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:157
+#: src/ui/preferences/scanner_page.py:158
 msgid "ClamD Configuration"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:158
+#: src/ui/preferences/scanner_page.py:159
 msgid "clamd.conf not found - Scanner settings unavailable"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:282
-#: src/ui/preferences/scanner_page.py:301
+#: src/ui/preferences/scanner_page.py:283
+#: src/ui/preferences/scanner_page.py:302
 msgid "Scan Backend"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:288
+#: src/ui/preferences/scanner_page.py:289
 msgid ""
 "Select how ClamUI performs scans. Daemon runs on host via flatpak-spawn. "
 "Auto-saved."
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:292
+#: src/ui/preferences/scanner_page.py:293
 msgid "Select how ClamUI performs scans. Auto-saved."
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:297
+#: src/ui/preferences/scanner_page.py:298
 msgid "Auto (prefer daemon)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:298
+#: src/ui/preferences/scanner_page.py:299
 msgid "ClamAV Daemon (clamd)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:299
+#: src/ui/preferences/scanner_page.py:300
 msgid "Standalone Scanner (clamscan)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:324
-#: src/ui/preferences/scanner_page.py:327
+#: src/ui/preferences/scanner_page.py:325
+#: src/ui/preferences/scanner_page.py:328
 msgid "Checking daemon connection..."
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:357
+#: src/ui/preferences/scanner_page.py:358
 msgid "Documentation"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:358
+#: src/ui/preferences/scanner_page.py:359
 msgid "About scan backends"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:381
+#: src/ui/preferences/scanner_page.py:382
 msgid ""
 "Recommended — Automatically uses daemon if available, falls back to clamscan "
 "for reliability"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:384
+#: src/ui/preferences/scanner_page.py:385
 msgid ""
 "Fastest — Instant startup with in-memory database, requires clamd service "
 "running"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:386
+#: src/ui/preferences/scanner_page.py:387
 msgid ""
 "Most compatible — Works anywhere, loads database each scan (3-10 sec startup)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:460
+#: src/ui/preferences/scanner_page.py:461
 msgid "Daemon available"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:461
+#: src/ui/preferences/scanner_page.py:462
 #, python-brace-format
 msgid "Not available: {message}"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:512
+#: src/ui/preferences/scanner_page.py:513
 msgid "Documentation Not Found"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:514
+#: src/ui/preferences/scanner_page.py:515
 msgid ""
 "The scan backends documentation file could not be found. It may have been "
 "moved or deleted."
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:532
+#: src/ui/preferences/scanner_page.py:534
 msgid "Error Opening Documentation"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:533
+#: src/ui/preferences/scanner_page.py:535
 #, python-brace-format
 msgid "Could not open documentation file: {error}"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:608
+#: src/ui/preferences/scanner_page.py:610
 msgid "File Type Scanning"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:609
+#: src/ui/preferences/scanner_page.py:611
 msgid "Enable or disable scanning for specific file types"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:614
+#: src/ui/preferences/scanner_page.py:616
 msgid "Scan PE Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:615
+#: src/ui/preferences/scanner_page.py:617
 msgid "Scan Windows/DOS executable files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:621
+#: src/ui/preferences/scanner_page.py:623
 msgid "Scan ELF Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:622
+#: src/ui/preferences/scanner_page.py:624
 msgid "Scan Unix/Linux executable files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:628
+#: src/ui/preferences/scanner_page.py:630
 msgid "Scan OLE2 Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:629
+#: src/ui/preferences/scanner_page.py:631
 msgid "Scan Microsoft Office documents"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:635
+#: src/ui/preferences/scanner_page.py:637
 msgid "Scan PDF Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:636
+#: src/ui/preferences/scanner_page.py:638
 msgid "Scan PDF documents"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:642
+#: src/ui/preferences/scanner_page.py:644
 msgid "Scan HTML Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:643
+#: src/ui/preferences/scanner_page.py:645
 msgid "Scan HTML documents"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:649
+#: src/ui/preferences/scanner_page.py:651
 msgid "Scan Archive Files"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:650
+#: src/ui/preferences/scanner_page.py:652
 msgid "Scan compressed archives (ZIP, RAR, etc.)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:673
+#: src/ui/preferences/scanner_page.py:675
 msgid "Performance and Limits"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:674
+#: src/ui/preferences/scanner_page.py:676
 msgid "Configure scanning limits and performance settings"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:691
+#: src/ui/preferences/scanner_page.py:693
 msgid "Max Scan Size (MB)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:692
+#: src/ui/preferences/scanner_page.py:694
 msgid "Maximum total scan size (0 = unlimited)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:703
+#: src/ui/preferences/scanner_page.py:705
 msgid "Max Archive Recursion"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:704
+#: src/ui/preferences/scanner_page.py:706
 msgid "Maximum recursion depth for archives"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:715
+#: src/ui/preferences/scanner_page.py:717
 msgid "Max Files in Archive"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:716
+#: src/ui/preferences/scanner_page.py:718
 msgid "Maximum number of files to scan in archive (0 = unlimited)"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:743
+#: src/ui/preferences/scanner_page.py:745
 msgid "Logging"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:744
+#: src/ui/preferences/scanner_page.py:746
 msgid "Configure logging options for the scanner"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:749
+#: src/ui/preferences/scanner_page.py:751
 msgid "Log File Path"
 msgstr ""
 
-#: src/ui/preferences/scanner_page.py:758
+#: src/ui/preferences/scanner_page.py:760
 msgid "Enable detailed scanner logging"
 msgstr ""
 
@@ -4454,7 +4582,7 @@ msgstr ""
 
 #: src/ui/profile_dialogs.py:190 src/ui/profile_dialogs.py:589
 #: src/ui/scan/target_selector.py:78 src/ui/scan/target_selector.py:233
-#: src/ui/scan_view.py:933 src/ui/scan_view.py:1218
+#: src/ui/scan_view.py:934 src/ui/scan_view.py:1219
 msgid "Scan Targets"
 msgstr ""
 
@@ -4470,7 +4598,7 @@ msgstr ""
 msgid "Add file"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:220 src/ui/scan_view.py:974
+#: src/ui/profile_dialogs.py:220 src/ui/scan_view.py:975
 msgid "No targets added"
 msgstr ""
 
@@ -4535,12 +4663,12 @@ msgstr ""
 msgid "Pattern"
 msgstr ""
 
-#: src/ui/profile_dialogs.py:529 src/ui/scan_view.py:1009
+#: src/ui/profile_dialogs.py:529 src/ui/scan_view.py:1010
 msgid "Remove"
 msgstr ""
 
 #: src/ui/profile_dialogs.py:587 src/ui/scan/target_selector.py:239
-#: src/ui/scan_view.py:1224
+#: src/ui/scan_view.py:1225
 #, python-brace-format
 msgid "Scan Targets ({count})"
 msgstr ""
@@ -4777,50 +4905,50 @@ msgstr ""
 msgid "Failed to delete file"
 msgstr ""
 
-#: src/ui/scan/profile_selector.py:50 src/ui/scan_view.py:732
+#: src/ui/scan/profile_selector.py:50 src/ui/scan_view.py:733
 msgid "Scan Profile"
 msgstr ""
 
-#: src/ui/scan/profile_selector.py:61 src/ui/scan_view.py:737
+#: src/ui/scan/profile_selector.py:61 src/ui/scan_view.py:738
 msgid "Profile"
 msgstr ""
 
 #: src/ui/scan/profile_selector.py:65 src/ui/scan/profile_selector.py:103
-#: src/ui/scan_view.py:743 src/ui/scan_view.py:828
+#: src/ui/scan_view.py:744 src/ui/scan_view.py:829
 msgid "No Profile (Manual)"
 msgstr ""
 
-#: src/ui/scan/profile_selector.py:75 src/ui/scan_view.py:755
+#: src/ui/scan/profile_selector.py:75 src/ui/scan_view.py:756
 msgid "Manage profiles"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:47 src/ui/scan_view.py:1286
+#: src/ui/scan/scan_progress_widget.py:47 src/ui/scan_view.py:1287
 msgid "Scan Progress"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:61 src/ui/scan/scan_view.py:284
-#: src/ui/scan_view.py:1300
+#: src/ui/scan/scan_progress_widget.py:61 src/ui/scan/scan_view.py:286
+#: src/ui/scan_view.py:1301
 msgid "Scanning..."
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:71 src/ui/scan_view.py:1310
+#: src/ui/scan/scan_progress_widget.py:71 src/ui/scan_view.py:1311
 msgid "Currently scanning"
 msgstr ""
 
 #: src/ui/scan/scan_progress_widget.py:72
-#: src/ui/scan/scan_progress_widget.py:117 src/ui/scan_view.py:1311
-#: src/ui/scan_view.py:1947
+#: src/ui/scan/scan_progress_widget.py:117 src/ui/scan_view.py:1312
+#: src/ui/scan_view.py:1948
 msgid "Waiting for scan data..."
 msgstr ""
 
 #: src/ui/scan/scan_progress_widget.py:82
-#: src/ui/scan/scan_progress_widget.py:120 src/ui/scan_view.py:1322
-#: src/ui/scan_view.py:1952
+#: src/ui/scan/scan_progress_widget.py:120 src/ui/scan_view.py:1323
+#: src/ui/scan_view.py:1953
 msgid "Scanned 0 files"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:92 src/ui/scan_results_dialog.py:202
-#: src/ui/scan_view.py:1332 src/ui/statistics_view.py:293
+#: src/ui/scan/scan_progress_widget.py:92 src/ui/scan_results_dialog.py:210
+#: src/ui/scan_view.py:1333 src/ui/statistics_view.py:293
 msgid "Threats Detected"
 msgstr ""
 
@@ -4835,30 +4963,30 @@ msgid "Scanning... {pct}%"
 msgstr ""
 
 #: src/ui/scan/scan_progress_widget.py:172
-#: src/ui/scan/scan_progress_widget.py:192 src/ui/scan_view.py:1544
-#: src/ui/scan_view.py:1564
+#: src/ui/scan/scan_progress_widget.py:192 src/ui/scan_view.py:1545
+#: src/ui/scan_view.py:1565
 #, python-brace-format
 msgid "Scanned {scanned} / {total} files"
 msgstr ""
 
 #: src/ui/scan/scan_progress_widget.py:179
-#: src/ui/scan/scan_progress_widget.py:200 src/ui/scan_view.py:1527
-#: src/ui/scan_view.py:1551 src/ui/scan_view.py:1572
+#: src/ui/scan/scan_progress_widget.py:200 src/ui/scan_view.py:1528
+#: src/ui/scan_view.py:1552 src/ui/scan_view.py:1573
 #, python-brace-format
 msgid "Scanned {scanned} files"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:184 src/ui/scan_view.py:1533
-#: src/ui/scan_view.py:1556
+#: src/ui/scan/scan_progress_widget.py:184 src/ui/scan_view.py:1534
+#: src/ui/scan_view.py:1557
 #, python-brace-format
 msgid "Target {current} of {total} ({cumulative} total)"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:210 src/ui/scan_view.py:1582
+#: src/ui/scan/scan_progress_widget.py:210 src/ui/scan_view.py:1583
 msgid "Unknown threat"
 msgstr ""
 
-#: src/ui/scan/scan_progress_widget.py:233 src/ui/scan_view.py:1610
+#: src/ui/scan/scan_progress_widget.py:233 src/ui/scan_view.py:1611
 #, python-brace-format
 msgid "Threats Detected ({n})"
 msgid_plural "Threats Detected ({n})"
@@ -4870,81 +4998,72 @@ msgstr[1] ""
 msgid "View Results ({n})"
 msgstr ""
 
-#: src/ui/scan/scan_results_widget.py:48 src/ui/scan_view.py:1701
-#: src/ui/scan_view.py:1726
+#: src/ui/scan/scan_results_widget.py:48 src/ui/scan_view.py:1702
+#: src/ui/scan_view.py:1727
 msgid "View Results"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:154 src/ui/scan_view.py:1243
+#: src/ui/scan/scan_view.py:161 src/ui/scan_view.py:1244
 msgid "Start Scan"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:160 src/ui/scan_view.py:1252
+#: src/ui/scan/scan_view.py:167 src/ui/scan_view.py:1253
 msgid "EICAR Test"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:162 src/ui/scan_view.py:2351
+#: src/ui/scan/scan_view.py:169 src/ui/scan_view.py:2366
 msgid "Run a scan with EICAR test file to verify antivirus detection"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:185 src/ui/scan_view.py:2377
+#: src/ui/scan/scan_view.py:192 src/ui/scan_view.py:2392
 #, python-brace-format
 msgid "Backend: {name}"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:201 src/ui/scan/target_selector.py:135
+#: src/ui/scan/scan_view.py:208 src/ui/scan/target_selector.py:135
 msgid "Cannot add targets while scanning"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:244 src/ui/scan_view.py:2244
+#: src/ui/scan/scan_view.py:251 src/ui/scan_view.py:2266
 #, python-brace-format
 msgid "Scan complete - {count} threat(s) detected"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:248 src/ui/scan_view.py:2255
-msgid "Scan complete - No threats found"
-msgstr ""
-
-#: src/ui/scan/scan_view.py:250 src/ui/scan_view.py:2252
-#, python-brace-format
-msgid "Scan complete - No threats found ({count} file(s) not accessible)"
-msgstr ""
-
-#: src/ui/scan/scan_view.py:258
+#: src/ui/scan/scan_view.py:260
 #, python-brace-format
 msgid "Scan error: {error}"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:271 src/ui/scan_view.py:1765
+#: src/ui/scan/scan_view.py:273 src/ui/scan_view.py:1766
 msgid "Please select a file or folder to scan"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:298 src/ui/scan_view.py:2192
+#: src/ui/scan/scan_view.py:300 src/ui/scan_view.py:2214
 #, python-brace-format
 msgid "Target {current} of {total}: {path}"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:303 src/ui/scan_view.py:1931
-#: src/ui/scan_view.py:2189
+#: src/ui/scan/scan_view.py:305 src/ui/scan_view.py:1932
+#: src/ui/scan_view.py:2211
 #, python-brace-format
 msgid "Scanning {path}"
 msgstr ""
 
-#: src/ui/scan/scan_view.py:326 src/ui/scan_view.py:1869
+#: src/ui/scan/scan_view.py:328 src/ui/scan_view.py:1870
 #, python-brace-format
 msgid "Failed to create EICAR test file: {error}"
 msgstr ""
 
 #: src/ui/scan/target_selector.py:79 src/ui/scan/target_selector.py:234
-#: src/ui/scan_view.py:934 src/ui/scan_view.py:1219
+#: src/ui/scan_view.py:935 src/ui/scan_view.py:1220
 msgid "Drop files here or click Add"
 msgstr ""
 
-#: src/ui/scan/target_selector.py:94 src/ui/scan_view.py:943
+#: src/ui/scan/target_selector.py:94 src/ui/scan_view.py:944
 msgid "Add files"
 msgstr ""
 
-#: src/ui/scan/target_selector.py:101 src/ui/scan_view.py:951
+#: src/ui/scan/target_selector.py:101 src/ui/scan_view.py:952
 msgid "Add folders"
 msgstr ""
 
@@ -4952,7 +5071,7 @@ msgstr ""
 msgid "No targets selected"
 msgstr ""
 
-#: src/ui/scan/target_selector.py:236 src/ui/scan_view.py:1221
+#: src/ui/scan/target_selector.py:236 src/ui/scan_view.py:1222
 msgid "Scan Target (1)"
 msgstr ""
 
@@ -4990,7 +5109,7 @@ msgstr ""
 msgid "Export results"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:133 src/ui/scan_results_dialog.py:616
+#: src/ui/scan_results_dialog.py:133 src/ui/scan_results_dialog.py:624
 #, python-brace-format
 msgid "Quarantine {n} Threat"
 msgid_plural "Quarantine All ({n})"
@@ -5006,308 +5125,313 @@ msgstr ""
 msgid "No threats found ({count} file(s) not accessible)"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:198 src/ui/scan_results_dialog.py:210
+#: src/ui/scan_results_dialog.py:196
+#, python-brace-format
+msgid "No threats found ({warning})"
+msgstr ""
+
+#: src/ui/scan_results_dialog.py:206 src/ui/scan_results_dialog.py:218
 #, python-brace-format
 msgid "{n} threat"
 msgid_plural "{n} threats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:203
+#: src/ui/scan_results_dialog.py:211
 #, python-brace-format
 msgid "{threat_text} found"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:215
+#: src/ui/scan_results_dialog.py:223
 #, python-brace-format
 msgid "Partial results - {threat_text} found"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:218
+#: src/ui/scan_results_dialog.py:226
 msgid "Partial results shown"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:240
+#: src/ui/scan_results_dialog.py:248
 msgid "Files scanned:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:243
+#: src/ui/scan_results_dialog.py:251
 msgid "Directories:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:248
+#: src/ui/scan_results_dialog.py:256
 msgid "Threats found:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:253
+#: src/ui/scan_results_dialog.py:261
 msgid "Not accessible:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:258
+#: src/ui/scan_results_dialog.py:266
 msgid "Error:"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:288
+#: src/ui/scan_results_dialog.py:296
 msgid "Files Not Accessible"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:292
+#: src/ui/scan_results_dialog.py:300
 msgid "Permission Denied"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:296
+#: src/ui/scan_results_dialog.py:304
 #, python-brace-format
 msgid "{n} file could not be scanned"
 msgid_plural "{n} files could not be scanned"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:324
+#: src/ui/scan_results_dialog.py:332
 #, python-brace-format
 msgid "... and {count} more"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:346
+#: src/ui/scan_results_dialog.py:354
 #, python-brace-format
 msgid ""
 "<b>Large result set:</b> Found {count} threats. Displaying first {limit}."
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:395 src/ui/virustotal_results_dialog.py:338
+#: src/ui/scan_results_dialog.py:403 src/ui/virustotal_results_dialog.py:338
 #, python-brace-format
 msgid "Show {count} more"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:458 src/ui/sidebar.py:31
+#: src/ui/scan_results_dialog.py:466 src/ui/sidebar.py:31
 msgid "Quarantine"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:466
+#: src/ui/scan_results_dialog.py:474
 msgid "Exclude"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:469
+#: src/ui/scan_results_dialog.py:477
 msgid "Add file path to exclusion list"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:475
+#: src/ui/scan_results_dialog.py:483
 msgid "Copy Path"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:492
+#: src/ui/scan_results_dialog.py:500
 msgid "Quarantined"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:502
+#: src/ui/scan_results_dialog.py:510
 #, python-brace-format
 msgid "Quarantined: {name}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:505
+#: src/ui/scan_results_dialog.py:513
 #, python-brace-format
 msgid "Failed: {error}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:511
+#: src/ui/scan_results_dialog.py:519
 msgid "Cannot access settings"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:522 src/ui/scan_results_dialog.py:537
+#: src/ui/scan_results_dialog.py:530 src/ui/scan_results_dialog.py:545
 msgid "Excluded"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:525
+#: src/ui/scan_results_dialog.py:533
 msgid "Path already in exclusion list"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:542
+#: src/ui/scan_results_dialog.py:550
 #, python-brace-format
 msgid "Added to exclusions: {name}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:548
+#: src/ui/scan_results_dialog.py:556
 #, python-brace-format
 msgid "Copied: {path}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:556
+#: src/ui/scan_results_dialog.py:564
 msgid "Quarantining..."
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:591
+#: src/ui/scan_results_dialog.py:599
 #, python-brace-format
 msgid "Quarantined {n} threat"
 msgid_plural "Quarantined {n} threats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_results_dialog.py:598
+#: src/ui/scan_results_dialog.py:606
 #, python-brace-format
 msgid "Quarantined {success}, failed {failed}"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:629
+#: src/ui/scan_results_dialog.py:637
 msgid "No results to export"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:638
+#: src/ui/scan_results_dialog.py:646
 msgid "Results copied to clipboard"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:639 src/ui/virustotal_results_dialog.py:452
+#: src/ui/scan_results_dialog.py:647 src/ui/virustotal_results_dialog.py:452
 msgid "Failed to copy results"
 msgstr ""
 
-#: src/ui/scan_results_dialog.py:647
+#: src/ui/scan_results_dialog.py:655
 msgid "Export Scan Results"
 msgstr ""
 
-#: src/ui/scan_view.py:426
+#: src/ui/scan_view.py:427
 msgid "Scan in progress - please wait until the current scan completes"
 msgstr ""
 
-#: src/ui/scan_view.py:433
+#: src/ui/scan_view.py:434
 msgid "No files were dropped"
 msgstr ""
 
-#: src/ui/scan_view.py:453
+#: src/ui/scan_view.py:454
 msgid "Unable to accept dropped files"
 msgstr ""
 
-#: src/ui/scan_view.py:514 src/ui/scan_view.py:707
+#: src/ui/scan_view.py:515 src/ui/scan_view.py:708
 msgid "Scan details"
 msgstr ""
 
-#: src/ui/scan_view.py:515
+#: src/ui/scan_view.py:516
 msgid "Detailed scan output appears here when available"
 msgstr ""
 
-#: src/ui/scan_view.py:524
+#: src/ui/scan_view.py:525
 msgid "Copy details"
 msgstr ""
 
-#: src/ui/scan_view.py:532
+#: src/ui/scan_view.py:533
 msgid "View details fullscreen"
 msgstr ""
 
-#: src/ui/scan_view.py:671
+#: src/ui/scan_view.py:672
 msgid "Error output:"
 msgstr ""
 
-#: src/ui/scan_view.py:677
+#: src/ui/scan_view.py:678
 msgid "Scan output:"
 msgstr ""
 
-#: src/ui/scan_view.py:694
+#: src/ui/scan_view.py:695
 msgid "Scan details copied to clipboard"
 msgstr ""
 
-#: src/ui/scan_view.py:695
+#: src/ui/scan_view.py:696
 msgid "Failed to copy scan details"
 msgstr ""
 
-#: src/ui/scan_view.py:697
+#: src/ui/scan_view.py:698
 msgid ""
 "Scan details are too large to copy. Use fullscreen to inspect the full "
 "output."
 msgstr ""
 
-#: src/ui/scan_view.py:875
+#: src/ui/scan_view.py:876
 #, python-brace-format
 msgid "Profile '{name}' has no valid targets"
 msgstr ""
 
-#: src/ui/scan_view.py:959
+#: src/ui/scan_view.py:960
 msgid "Clear all"
 msgstr ""
 
-#: src/ui/scan_view.py:975
+#: src/ui/scan_view.py:976
 msgid "Drop files here or click Add Files/Folders"
 msgstr ""
 
-#: src/ui/scan_view.py:1051
+#: src/ui/scan_view.py:1052
 msgid "Select Files to Scan"
 msgstr ""
 
-#: src/ui/scan_view.py:1073
+#: src/ui/scan_view.py:1074
 msgid "Select Folders to Scan"
 msgstr ""
 
-#: src/ui/scan_view.py:1244
+#: src/ui/scan_view.py:1245
 msgid "Start Scan (F5)"
 msgstr ""
 
-#: src/ui/scan_view.py:1261 src/ui/scan_view.py:1907
+#: src/ui/scan_view.py:1262 src/ui/scan_view.py:1908
 msgid "Cancel the current scan"
 msgstr ""
 
-#: src/ui/scan_view.py:1498
+#: src/ui/scan_view.py:1499
 #, python-brace-format
 msgid "Target {current} of {total} \\u2014 {pct}%{overflow}"
 msgstr ""
 
-#: src/ui/scan_view.py:1507
+#: src/ui/scan_view.py:1508
 #, python-brace-format
 msgid "Scanning... {pct}%{overflow}"
 msgstr ""
 
-#: src/ui/scan_view.py:1718
+#: src/ui/scan_view.py:1719
 #, python-brace-format
 msgid "View Results ({n} Threat)"
 msgid_plural "View Results ({n} Threats)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/scan_view.py:1903
+#: src/ui/scan_view.py:1904
 msgid "Cancel All"
 msgstr ""
 
-#: src/ui/scan_view.py:1904
+#: src/ui/scan_view.py:1905
 msgid "Cancel all remaining scans"
 msgstr ""
 
-#: src/ui/scan_view.py:1928
+#: src/ui/scan_view.py:1929
 #, python-brace-format
 msgid "Scanning {path} \\u2014 File count pending"
 msgstr ""
 
-#: src/ui/scan_view.py:1935
+#: src/ui/scan_view.py:1936
 #, python-brace-format
 msgid "Scanning {count} items \\u2014 File count pending"
 msgstr ""
 
-#: src/ui/scan_view.py:1941
+#: src/ui/scan_view.py:1942
 #, python-brace-format
 msgid "Scanning {count} items"
 msgstr ""
 
-#: src/ui/scan_view.py:2267 src/ui/scan_view.py:2321
+#: src/ui/scan_view.py:2282 src/ui/scan_view.py:2336
 #, python-brace-format
 msgid "Scan error: {detail}"
 msgstr ""
 
-#: src/ui/scan_view.py:2274 src/ui/scan_view.py:2324
+#: src/ui/scan_view.py:2289 src/ui/scan_view.py:2339
 msgid "Detailed scan error output"
 msgstr ""
 
-#: src/ui/scan_view.py:2275
+#: src/ui/scan_view.py:2290
 msgid "Detailed ClamAV output from the latest failed scan"
 msgstr ""
 
-#: src/ui/scan_view.py:2286
+#: src/ui/scan_view.py:2301
 #, python-brace-format
 msgid "Scan completed with status: {status}"
 msgstr ""
 
-#: src/ui/scan_view.py:2325
+#: src/ui/scan_view.py:2340
 msgid "Detailed application error output from the latest failed scan"
 msgstr ""
 
-#: src/ui/scan_view.py:2383
+#: src/ui/scan_view.py:2398
 msgid "Ready to scan"
 msgstr ""
 
-#: src/ui/scan_view.py:2384 src/ui/update_view.py:173
+#: src/ui/scan_view.py:2399 src/ui/update_view.py:173
 msgid "Dismiss"
 msgstr ""
 

--- a/src/app.py
+++ b/src/app.py
@@ -83,7 +83,7 @@ class ClamUIApp(Adw.Application):
     - Tray: _on_tray_quick_scan, _on_tray_full_scan, _on_tray_update,
             _on_tray_quit, _on_tray_window_toggle, _on_tray_profile_select
     - Quick scan: _on_statistics_quick_scan, _do_tray_quick_scan
-    - Settings: _get_quick_scan_profile, switch_to_view, set_initial_scan_paths
+    - Settings: _get_quick_scan_profile, set_initial_scan_paths
 
     Collaboration:
     - AppLifecycleManager: Handles shutdown, device monitor, database dir
@@ -863,10 +863,6 @@ class ClamUIApp(Adw.Application):
             win.set_active_view(view_name)
             self._current_view = view_name
 
-    def switch_to_view(self, view_name: str):
-        """Switch the active view by name (e.g. "scan", "logs")."""
-        self._view_coordinator.switch_to_view(view_name, getattr(self, f"{view_name}_view"))
-
     def _show_window_toast(self, message: str) -> None:
         """Show a toast notification on the main window if one is available."""
         win = self.props.active_window
@@ -907,7 +903,7 @@ class ClamUIApp(Adw.Application):
 
         # Surface the scan UI so a second invocation does not start a scan
         # invisibly under whichever view is currently shown.
-        self.switch_to_view("scan")
+        self._view_coordinator.switch_to_view("scan", self.scan_view)
 
         if use_vt:
             # VirusTotal scans a single file per request; only the first

--- a/src/app.py
+++ b/src/app.py
@@ -863,6 +863,16 @@ class ClamUIApp(Adw.Application):
             win.set_active_view(view_name)
             self._current_view = view_name
 
+    def switch_to_view(self, view_name: str):
+        """Switch the active view by name (e.g. "scan", "logs")."""
+        self._view_coordinator.switch_to_view(view_name, getattr(self, f"{view_name}_view"))
+
+    def _show_window_toast(self, message: str) -> None:
+        """Show a toast notification on the main window if one is available."""
+        win = self.props.active_window
+        if win is not None and hasattr(win, "add_toast"):
+            win.add_toast(Adw.Toast.new(message))
+
     def set_initial_scan_paths(self, file_paths: list[str], use_virustotal: bool = False):
         """Store initial scan paths from CLI or file manager integration."""
         self._initial_scan_paths = file_paths
@@ -874,23 +884,52 @@ class ClamUIApp(Adw.Application):
         if not self._initial_scan_paths:
             return
 
+        if not self._scan_view:
+            # Keep the request pending; do_activate re-processes it once the
+            # scan view has been created.
+            return
+
+        if self._scan_view.is_scanning:
+            # Repopulating the selection now would mutate the target list the
+            # scan worker thread is using; drop the request and tell the user.
+            self._initial_scan_paths = []
+            self._initial_use_virustotal = False
+            self._show_window_toast(
+                _("A scan is already running — the new scan request was ignored")
+            )
+            return
+
         paths = self._initial_scan_paths
         self._initial_scan_paths = []
 
         use_vt = self._initial_use_virustotal
         self._initial_use_virustotal = False
 
-        if self._scan_view:
-            if use_vt:
-                # VirusTotal scans a single file per request; only the first
-                # path is forwarded to the setup dialog and scan pipeline.
-                self._scan_view._set_selected_path(paths[0])
-                self._show_virustotal_setup_dialog(paths[0])
-            else:
-                # ClamAV scans every CLI-provided target (files and folders),
-                # so populate the full selection before starting.
-                self._scan_view._replace_selected_paths(paths)
-                self._scan_view._start_scan()
+        # Surface the scan UI so a second invocation does not start a scan
+        # invisibly under whichever view is currently shown.
+        self.switch_to_view("scan")
+
+        if use_vt:
+            # VirusTotal scans a single file per request; only the first
+            # path is forwarded to the setup dialog and scan pipeline.
+            if len(paths) > 1:
+                ignored_count = len(paths) - 1
+                self._show_window_toast(
+                    ngettext(
+                        "VirusTotal scans one file per request — "
+                        "{count} additional selection was ignored",
+                        "VirusTotal scans one file per request — "
+                        "{count} additional selections were ignored",
+                        ignored_count,
+                    ).format(count=ignored_count)
+                )
+            self._scan_view._set_selected_path(paths[0])
+            self._show_virustotal_setup_dialog(paths[0])
+        else:
+            # ClamAV scans every CLI-provided target (files and folders),
+            # so populate the full selection before starting.
+            self._scan_view._replace_selected_paths(paths)
+            self._scan_view._start_scan()
 
     def _trigger_virustotal_scan(self, file_path: str, api_key: str) -> None:
         """Trigger a VirusTotal scan for the specified file."""

--- a/src/core/daemon_scanner.py
+++ b/src/core/daemon_scanner.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from gi.repository import GLib
 
 from .flatpak import is_flatpak, wrap_host_command
+from .i18n import _
 from .log_manager import LogManager
 from .sanitize import sanitize_surrogate_path
 from .scanner_base import (
@@ -26,6 +27,7 @@ from .scanner_base import (
     communicate_with_cancel_check,
     create_cancelled_result,
     create_error_result,
+    parse_total_errors,
     save_scan_log,
     stream_process_output,
     terminate_process_gracefully,
@@ -848,7 +850,16 @@ class DaemonScanner:
             if exit_code == 2 and skipped_files:
                 warning_message = f"{len(skipped_files)} file(s) could not be accessed"
         elif exit_code == 0:
-            status = ScanStatus.ERROR if hard_error_lines else ScanStatus.CLEAN
+            # Exit 0 is the daemon's authoritative success signal. Only genuine
+            # error replies (per-file "... ERROR" or clamdscan's own "ERROR:" /
+            # "LibClamAV Error:" lines) may override it — stray unrecognized
+            # warning lines must not flip a successful scan to ERROR.
+            genuine_error_lines = [
+                line
+                for line in hard_error_lines
+                if line.endswith(" ERROR") or line.startswith(("ERROR:", "LibClamAV Error:"))
+            ]
+            status = ScanStatus.ERROR if genuine_error_lines else ScanStatus.CLEAN
         elif exit_code == 1:
             status = ScanStatus.INFECTED
         elif exit_code == 2:
@@ -858,10 +869,22 @@ class DaemonScanner:
             # identified the cause as non-fatal (a skipped file or a limit/truncation
             # warning) and nothing looked like a hard error. Unrecognized stderr
             # stays ERROR.
+            total_errors = parse_total_errors(stdout)
             if not hard_error_lines and (skipped_files or nonfatal_warnings):
                 status = ScanStatus.CLEAN
                 if skipped_files:
                     warning_message = f"{len(skipped_files)} file(s) could not be accessed"
+                else:
+                    warning_message = _(
+                        "{count} non-fatal warning(s) during scan; some files may "
+                        "have been only partially scanned"
+                    ).format(count=len(nonfatal_warnings))
+            elif not hard_error_lines and total_errors > 0:
+                # -i mode suppresses per-file "Access denied" lines, so the
+                # summary's "Total errors: N" is the only positive signal that
+                # exit 2 was caused by unreadable files, not a scan failure.
+                status = ScanStatus.CLEAN
+                warning_message = _("{count} file(s) could not be read").format(count=total_errors)
             else:
                 status = ScanStatus.ERROR
         else:
@@ -896,6 +919,7 @@ class DaemonScanner:
             skipped_files=skipped_files,
             skipped_count=len(skipped_files),
             warning_message=warning_message,
+            nonfatal_warnings=nonfatal_warnings,
         )
 
     def _collect_exclusion_patterns(self, profile_exclusions: dict | None = None) -> list[str]:
@@ -1053,6 +1077,8 @@ class DaemonScanner:
                 threat_details=[],
                 skipped_files=result.skipped_files,
                 skipped_count=result.skipped_count,
+                warning_message=result.warning_message,
+                nonfatal_warnings=result.nonfatal_warnings,
             )
 
         return ScanResult(
@@ -1069,6 +1095,8 @@ class DaemonScanner:
             threat_details=filtered_threats,
             skipped_files=result.skipped_files,
             skipped_count=result.skipped_count,
+            warning_message=result.warning_message,
+            nonfatal_warnings=result.nonfatal_warnings,
         )
 
     def _save_scan_log(self, result: ScanResult, duration: float) -> None:

--- a/src/core/daemon_scanner.py
+++ b/src/core/daemon_scanner.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from gi.repository import GLib
 
 from .flatpak import is_flatpak, wrap_host_command
-from .i18n import _
 from .log_manager import LogManager
 from .sanitize import sanitize_surrogate_path
 from .scanner_base import (
@@ -27,7 +26,8 @@ from .scanner_base import (
     communicate_with_cancel_check,
     create_cancelled_result,
     create_error_result,
-    parse_total_errors,
+    is_genuine_error_line,
+    resolve_exit2_status,
     save_scan_log,
     stream_process_output,
     terminate_process_gracefully,
@@ -842,6 +842,7 @@ class DaemonScanner:
 
         # Determine overall status based on exit code
         warning_message = None
+        exit2_error_message = None
         if infected_count > 0:
             # Detections are authoritative: clamdscan returns exit code 2 when it
             # both finds a virus and hits an error (e.g. an unreadable file), so
@@ -854,46 +855,29 @@ class DaemonScanner:
             # error replies (per-file "... ERROR" or clamdscan's own "ERROR:" /
             # "LibClamAV Error:" lines) may override it — stray unrecognized
             # warning lines must not flip a successful scan to ERROR.
-            genuine_error_lines = [
-                line
-                for line in hard_error_lines
-                if line.endswith(" ERROR") or line.startswith(("ERROR:", "LibClamAV Error:"))
-            ]
+            genuine_error_lines = [line for line in hard_error_lines if is_genuine_error_line(line)]
             status = ScanStatus.ERROR if genuine_error_lines else ScanStatus.CLEAN
         elif exit_code == 1:
             status = ScanStatus.INFECTED
         elif exit_code == 2:
-            # Exit code 2 = warnings/errors. clamscan/clamdscan report 2 even for
-            # benign, by-design situations (unreadable files, files exceeding scan
-            # limits, truncated archives). Treat as CLEAN only when we positively
-            # identified the cause as non-fatal (a skipped file or a limit/truncation
-            # warning) and nothing looked like a hard error. Unrecognized stderr
-            # stays ERROR.
-            total_errors = parse_total_errors(stdout)
-            if not hard_error_lines and (skipped_files or nonfatal_warnings):
-                status = ScanStatus.CLEAN
-                if skipped_files:
-                    warning_message = f"{len(skipped_files)} file(s) could not be accessed"
-                else:
-                    warning_message = _(
-                        "{count} non-fatal warning(s) during scan; some files may "
-                        "have been only partially scanned"
-                    ).format(count=len(nonfatal_warnings))
-            elif not hard_error_lines and total_errors > 0:
-                # -i mode suppresses per-file "Access denied" lines, so the
-                # summary's "Total errors: N" is the only positive signal that
-                # exit 2 was caused by unreadable files, not a scan failure.
-                status = ScanStatus.CLEAN
-                warning_message = _("{count} file(s) could not be read").format(count=total_errors)
-            else:
-                status = ScanStatus.ERROR
+            # scanned_files here is ClamUI's own pre-count of scan targets
+            # (clamdscan reports no summary counts), so the helper compares
+            # failure signals against it instead of requiring it to be > 0.
+            status, warning_message, exit2_error_message = resolve_exit2_status(
+                stdout,
+                file_count,
+                hard_error_lines,
+                skipped_files,
+                nonfatal_warnings,
+                scanned_is_precount=True,
+            )
         else:
             status = ScanStatus.ERROR
 
         # Prefer stderr for hard errors, but fall back to a concise stdout line when stderr is empty.
         error_message: str | None = None
         if status == ScanStatus.ERROR:
-            error_message = stderr.strip() or None
+            error_message = exit2_error_message or stderr.strip() or None
             if error_message is None:
                 if hard_error_lines:
                     error_message = hard_error_lines[0]

--- a/src/core/file_manager_integration.py
+++ b/src/core/file_manager_integration.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-from .flatpak import is_flatpak, wrap_host_command
+from .flatpak import get_clean_env, is_flatpak, wrap_host_command
 from .i18n import N_, _
 from .path_validation import validate_path
 
@@ -313,6 +313,7 @@ def _refresh_dolphin_service_menu_cache() -> None:
                 check=True,
                 text=True,
                 timeout=10,
+                env=get_clean_env(),
             )
             logger.info("Refreshed KDE service menu cache via %s", binary)
             return

--- a/src/core/flatpak.py
+++ b/src/core/flatpak.py
@@ -339,6 +339,7 @@ def get_xdg_user_dir(dir_type: str) -> str | None:
             capture_output=True,
             text=True,
             timeout=5,
+            env=get_clean_env(),
         )
         resolved = result.stdout.strip()
         if result.returncode == 0 and resolved:

--- a/src/core/flatpak.py
+++ b/src/core/flatpak.py
@@ -66,14 +66,23 @@ def get_clean_env() -> dict[str, str]:
     - ``GI_TYPELIB_PATH``: the GObject-introspection analog of LD_LIBRARY_PATH;
       a host tool that ``import gi`` (firewall-cmd does) would otherwise load the
       bundled typelibs against host GLib -> version mismatch.
+    - ``GTK_PATH``/``GTK_EXE_PREFIX``/``GTK_DATA_PREFIX``/``GSETTINGS_SCHEMA_DIR``/
+      ``GDK_PIXBUF_MODULE_FILE``/``GDK_PIXBUF_MODULEDIR``: point host GTK apps
+      (gufw, firewall-config) at the AppImage's bundled GTK modules, compiled
+      GSettings schemas, and pixbuf loaders -> module ABI mismatches or
+      missing-schema aborts.
+
+    ``XDG_DATA_DIRS`` is intentionally NOT stripped: AppRun only prepends the
+    bundled share dir and host tools still need the host entries it contains.
 
     Every caller spawns native HOST binaries, never ClamUI's bundled Python, so
     stripping these is always safe. Popping an unset var is a no-op.
     """
     env = os.environ.copy()
     # Strip AppImage-injected runtime overrides that break host helpers: library
-    # paths (ABI conflicts), Python home/path (host script bootstrap), and the
-    # introspection typelib path (gi version mismatch). See GitHub issue #155.
+    # paths (ABI conflicts), Python home/path (host script bootstrap), the
+    # introspection typelib path (gi version mismatch), and GTK module/schema/
+    # pixbuf overrides (host GTK apps). See GitHub issue #155.
     for var in (
         "LD_LIBRARY_PATH",
         "LD_PRELOAD",
@@ -81,6 +90,12 @@ def get_clean_env() -> dict[str, str]:
         "PYTHONPATH",
         "PYTHONDONTWRITEBYTECODE",
         "GI_TYPELIB_PATH",
+        "GTK_PATH",
+        "GTK_EXE_PREFIX",
+        "GTK_DATA_PREFIX",
+        "GSETTINGS_SCHEMA_DIR",
+        "GDK_PIXBUF_MODULE_FILE",
+        "GDK_PIXBUF_MODULEDIR",
     ):
         env.pop(var, None)
     # Remove AppImage-specific variables that may affect library resolution

--- a/src/core/log_manager.py
+++ b/src/core/log_manager.py
@@ -2078,7 +2078,9 @@ class LogManager:
             try:
                 # Use tail command - wrapped for Flatpak host access
                 tail_cmd = wrap_host_command(["tail", "-n", str(num_lines), log_path])
-                result = subprocess.run(tail_cmd, capture_output=True, text=True, timeout=10)
+                result = subprocess.run(
+                    tail_cmd, capture_output=True, text=True, timeout=10, env=get_clean_env()
+                )
 
                 if result.returncode == 0:
                     content = result.stdout
@@ -2156,7 +2158,9 @@ class LogManager:
                         "-q",  # Quiet - suppress info messages
                     ]
                 )
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=10, env=get_clean_env()
+                )
 
                 if result.returncode == 0 and result.stdout.strip():
                     return (True, _sanitize_private_text(result.stdout))

--- a/src/core/result_formatters.py
+++ b/src/core/result_formatters.py
@@ -6,6 +6,7 @@ This module provides functions for:
 - Formatting ScanResult objects as human-readable text reports
 - Formatting ScanResult objects as CSV for spreadsheet export
 - Generating exportable scan reports with timestamps and threat details
+- Composing aggregated warning and status messages for scan results
 """
 
 import csv
@@ -17,6 +18,48 @@ from .i18n import _
 
 if TYPE_CHECKING:
     from .scanner import ScanResult
+
+
+def compose_scan_warning(skipped_count: int, warning_messages: list[str]) -> str | None:
+    """
+    Compose the aggregated warning message for a (multi-target) scan.
+
+    Args:
+        skipped_count: Number of files that could not be accessed
+        warning_messages: Distinct per-target warning messages
+
+    Returns:
+        The skipped-file count phrase when files were skipped, otherwise the
+        joined distinct per-target messages (e.g. non-fatal scanner warnings),
+        or None when there is nothing to warn about.
+    """
+    if skipped_count > 0:
+        return _("{count} file(s) could not be accessed").format(count=skipped_count)
+    if warning_messages:
+        return "; ".join(warning_messages)
+    return None
+
+
+def clean_scan_status_message(result: "ScanResult") -> str:
+    """
+    Build the status banner message for a clean scan result.
+
+    Args:
+        result: A clean ScanResult
+
+    Returns:
+        The banner message, including the skipped-file count or the warning
+        message when present. Never renders a bare "0 file(s)" phrase.
+    """
+    if result.skipped_count > 0:
+        return _("Scan complete - No threats found ({count} file(s) not accessible)").format(
+            count=result.skipped_count
+        )
+    if result.warning_message:
+        return _("Scan complete - No threats found ({warning})").format(
+            warning=result.warning_message
+        )
+    return _("Scan complete - No threats found")
 
 
 def format_results_as_text(result: "ScanResult", timestamp: str | None = None) -> str:

--- a/src/core/scanner.py
+++ b/src/core/scanner.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 from gi.repository import GLib
 
 from .clamav_config import parse_config
-from .i18n import _
 from .log_manager import LogManager
 from .scanner_base import (
     cleanup_process,
@@ -25,7 +24,7 @@ from .scanner_base import (
     communicate_with_cancel_check,
     create_cancelled_result,
     create_error_result,
-    parse_total_errors,
+    resolve_exit2_status,
     save_scan_log,
     stream_process_output,
     terminate_process_gracefully,
@@ -930,6 +929,7 @@ class Scanner:
 
         # Determine overall status based on exit code
         warning_message = None
+        exit2_error_message = None
         if infected_count > 0:
             # Detections are authoritative: clamscan returns exit code 2 when it
             # both finds a virus and hits an error (e.g. an unreadable file), so
@@ -942,35 +942,19 @@ class Scanner:
         elif exit_code == 1:
             status = ScanStatus.INFECTED
         elif exit_code == 2:
-            # Exit code 2 = warnings/errors. clamscan reports 2 even for benign,
-            # by-design situations (unreadable files, files exceeding scan limits,
-            # truncated archives). Treat as CLEAN only when we positively identified
-            # the cause as non-fatal (a skipped file or a limit/truncation warning)
-            # and nothing looked like a hard error. Unrecognized stderr stays ERROR.
-            total_errors = parse_total_errors(stdout)
-            if not hard_error_lines and (skipped_files or nonfatal_warnings):
-                status = ScanStatus.CLEAN
-                if skipped_files:
-                    warning_message = f"{len(skipped_files)} file(s) could not be accessed"
-                else:
-                    warning_message = _(
-                        "{count} non-fatal warning(s) during scan; some files may "
-                        "have been only partially scanned"
-                    ).format(count=len(nonfatal_warnings))
-            elif not hard_error_lines and total_errors > 0:
-                # -i mode suppresses per-file "Access denied" lines, so the
-                # summary's "Total errors: N" is the only positive signal that
-                # exit 2 was caused by unreadable files, not a scan failure.
-                status = ScanStatus.CLEAN
-                warning_message = _("{count} file(s) could not be read").format(count=total_errors)
-            else:
-                status = ScanStatus.ERROR
+            status, warning_message, exit2_error_message = resolve_exit2_status(
+                stdout, scanned_files, hard_error_lines, skipped_files, nonfatal_warnings
+            )
         else:
             status = ScanStatus.ERROR
 
         error_message = None
         if status == ScanStatus.ERROR:
-            error_message = stderr.strip() or (hard_error_lines[0] if hard_error_lines else None)
+            error_message = (
+                exit2_error_message
+                or stderr.strip()
+                or (hard_error_lines[0] if hard_error_lines else None)
+            )
 
         return ScanResult(
             status=status,

--- a/src/core/scanner.py
+++ b/src/core/scanner.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from gi.repository import GLib
 
 from .clamav_config import parse_config
+from .i18n import _
 from .log_manager import LogManager
 from .scanner_base import (
     cleanup_process,
@@ -24,6 +25,7 @@ from .scanner_base import (
     communicate_with_cancel_check,
     create_cancelled_result,
     create_error_result,
+    parse_total_errors,
     save_scan_log,
     stream_process_output,
     terminate_process_gracefully,
@@ -246,7 +248,7 @@ class Scanner:
         ):
             return Scanner._daemon_cache[1]
 
-        is_available, _ = check_clamd_connection(config_path=self._get_clamd_config_path())
+        is_available, _msg = check_clamd_connection(config_path=self._get_clamd_config_path())
         Scanner._daemon_cache = (now, is_available)
         return is_available
 
@@ -261,7 +263,7 @@ class Scanner:
         if backend == "clamscan":
             return "clamscan"
         elif backend == "daemon":
-            is_available, _ = self._get_daemon_scanner().check_available()
+            is_available, _msg = self._get_daemon_scanner().check_available()
             return "daemon" if is_available else "unavailable"
         else:  # auto
             is_available = self._is_daemon_available_cached()
@@ -945,10 +947,22 @@ class Scanner:
             # truncated archives). Treat as CLEAN only when we positively identified
             # the cause as non-fatal (a skipped file or a limit/truncation warning)
             # and nothing looked like a hard error. Unrecognized stderr stays ERROR.
+            total_errors = parse_total_errors(stdout)
             if not hard_error_lines and (skipped_files or nonfatal_warnings):
                 status = ScanStatus.CLEAN
                 if skipped_files:
                     warning_message = f"{len(skipped_files)} file(s) could not be accessed"
+                else:
+                    warning_message = _(
+                        "{count} non-fatal warning(s) during scan; some files may "
+                        "have been only partially scanned"
+                    ).format(count=len(nonfatal_warnings))
+            elif not hard_error_lines and total_errors > 0:
+                # -i mode suppresses per-file "Access denied" lines, so the
+                # summary's "Total errors: N" is the only positive signal that
+                # exit 2 was caused by unreadable files, not a scan failure.
+                status = ScanStatus.CLEAN
+                warning_message = _("{count} file(s) could not be read").format(count=total_errors)
             else:
                 status = ScanStatus.ERROR
         else:
@@ -973,6 +987,7 @@ class Scanner:
             skipped_files=skipped_files,
             skipped_count=len(skipped_files),
             warning_message=warning_message,
+            nonfatal_warnings=nonfatal_warnings,
         )
 
     def _save_scan_log(self, result: ScanResult, duration: float) -> None:

--- a/src/core/scanner_base.py
+++ b/src/core/scanner_base.py
@@ -13,6 +13,7 @@ DaemonScanner (clamdscan) to avoid code duplication:
 
 import logging
 import os
+import re
 import select
 import subprocess
 from collections.abc import Callable
@@ -38,7 +39,13 @@ _NONFATAL_SKIP_MARKERS = (
     ": Failed to open file",
     ": File path check failure:",
     ": Not supported file type",
+    ": Can't access file",  # clamscan lstat() failure (e.g. file deleted mid-scan)
+    ": Access denied",  # per-file EACCES line (clamscan -v / clamdscan "Access denied. ERROR")
+    ": Time limit reached",  # per-file CL_ETIMEOUT; file partially scanned, scan continues
 )
+# Warnings where the skipped path FOLLOWS the marker instead of preceding it:
+# "WARNING: Can't open file <path>: <strerror text>" (clamscan open() failure).
+_NONFATAL_SKIP_PATH_PREFIXES = ("WARNING: Can't open file ",)
 _IGNORABLE_WARNING_LINES = ("LibClamAV Warning: cli_realpath: Invalid arguments.",)
 
 # LibClamAV Error patterns from non-fatal file parsing (CL_EPARSE/CL_EFORMAT).
@@ -61,7 +68,28 @@ _NONFATAL_WARNING_PATTERNS = (
     "size limit reached",  # generic scan/file size cap reached
     "recursion limit",  # archive/container recursion depth cap
     "max recursion level reached",  # cli_magic_scan recursion cap
+    "cannot dlopen libclamunrar",  # optional unrar module missing; scan continues without it
+    "bytecode run timed out",  # bytecode signature timeout; file scan continues
 )
+
+# Matches the "Total errors: N" line from the clamscan/clamdscan scan summary.
+_TOTAL_ERRORS_RE = re.compile(r"^Total errors:\s*(\d+)$")
+
+
+def parse_total_errors(stdout: str) -> int:
+    """Extract the error count from the ClamAV scan-summary block.
+
+    Both clamscan and clamdscan print "Total errors: N" in their summary when
+    at least one file could not be read. In -i mode the per-file "Access
+    denied" lines are suppressed, so this summary line can be the only
+    positive signal that an exit code of 2 was caused by unreadable files
+    rather than a scan failure. Returns 0 when the line is absent.
+    """
+    for raw_line in stdout.splitlines():
+        match = _TOTAL_ERRORS_RE.match(raw_line.strip())
+        if match:
+            return int(match.group(1))
+    return 0
 
 
 def communicate_with_cancel_check(
@@ -382,6 +410,13 @@ def _extract_skipped_path(line: str) -> str | None:
                 file_path = file_path[len("WARNING:") :].strip()
             if file_path.startswith("ERROR:"):
                 file_path = file_path[len("ERROR:") :].strip()
+            return file_path or None
+    for prefix in _NONFATAL_SKIP_PATH_PREFIXES:
+        if line.startswith(prefix):
+            rest = line[len(prefix) :]
+            # "<path>: <strerror text>" — strerror messages contain no colon,
+            # so splitting on the last colon keeps colons inside the path.
+            file_path = rest.rsplit(":", 1)[0].strip() if ":" in rest else rest.strip()
             return file_path or None
     return None
 

--- a/src/core/scanner_base.py
+++ b/src/core/scanner_base.py
@@ -41,8 +41,10 @@ _NONFATAL_SKIP_MARKERS = (
     ": Not supported file type",
     ": Can't access file",  # clamscan lstat() failure (e.g. file deleted mid-scan)
     ": Access denied",  # per-file EACCES line (clamscan -v / clamdscan "Access denied. ERROR")
-    ": Time limit reached",  # per-file CL_ETIMEOUT; file partially scanned, scan continues
 )
+# Lines where the marker comes FIRST and the remainder of the line IS the path:
+# "ERROR: Can't access file <path>" (clamdscan stat() failure, proto.c error_stat).
+_NONFATAL_SKIP_MARKER_FIRST_PREFIXES = ("ERROR: Can't access file ",)
 # Warnings where the skipped path FOLLOWS the marker instead of preceding it:
 # "WARNING: Can't open file <path>: <strerror text>" (clamscan open() failure).
 _NONFATAL_SKIP_PATH_PREFIXES = ("WARNING: Can't open file ",)
@@ -71,6 +73,12 @@ _NONFATAL_WARNING_PATTERNS = (
     "cannot dlopen libclamunrar",  # optional unrar module missing; scan continues without it
     "bytecode run timed out",  # bytecode signature timeout; file scan continues
 )
+
+# Per-file CL_ETIMEOUT reply: "<path>: Time limit reached ERROR". The file was
+# PARTIALLY scanned before the per-file time limit hit and the scan continued,
+# so it belongs in nonfatal_warnings — reporting it as "not accessible" would
+# be wrong.
+_NONFATAL_TIME_LIMIT_MARKER = ": Time limit reached"
 
 # Matches the "Total errors: N" line from the clamscan/clamdscan scan summary.
 _TOTAL_ERRORS_RE = re.compile(r"^Total errors:\s*(\d+)$")
@@ -403,6 +411,9 @@ def stream_process_output(
 
 def _extract_skipped_path(line: str) -> str | None:
     """Extract a skipped-file path from a known non-fatal ClamAV warning line."""
+    for prefix in _NONFATAL_SKIP_MARKER_FIRST_PREFIXES:
+        if line.startswith(prefix):
+            return line[len(prefix) :].strip() or None
     for marker in _NONFATAL_SKIP_MARKERS:
         if marker in line:
             file_path = line.split(marker, 1)[0].strip()
@@ -410,6 +421,11 @@ def _extract_skipped_path(line: str) -> str | None:
                 file_path = file_path[len("WARNING:") :].strip()
             if file_path.startswith("ERROR:"):
                 file_path = file_path[len("ERROR:") :].strip()
+            if file_path in ("WARNING", "ERROR"):
+                # Marker-first wording we don't recognize ("ERROR: Can't access
+                # <something> ..."): the text before the marker is a severity
+                # token, not a path. Leave it to hard-error classification.
+                return None
             return file_path or None
     for prefix in _NONFATAL_SKIP_PATH_PREFIXES:
         if line.startswith(prefix):
@@ -474,12 +490,107 @@ def collect_clamav_warnings(stdout: str, stderr: str) -> tuple[list[str], list[s
             nonfatal_warnings.append(line)
             continue
 
+        # Per-file CL_ETIMEOUT ("<path>: Time limit reached ERROR"): the file
+        # was partially scanned and the scan continued, so classify it as a
+        # non-fatal warning rather than a skipped (inaccessible) file.
+        if _NONFATAL_TIME_LIMIT_MARKER in line:
+            nonfatal_warnings.append(line)
+            continue
+
         if line.startswith(
             ("WARNING:", "ERROR:", "LibClamAV Error:", "LibClamAV Warning:")
         ) or line.endswith("ERROR"):
             hard_error_lines.append(line)
 
     return skipped_files, nonfatal_warnings, hard_error_lines
+
+
+def is_genuine_error_line(line: str) -> bool:
+    """Return True for lines that are unambiguous ClamAV error replies.
+
+    Matches per-file "... ERROR" replies and clamscan/clamdscan's own
+    "ERROR:" / "LibClamAV Error:" lines. Stray unrecognized warning lines do
+    NOT qualify, so a successful (exit 0) scan is not flipped to ERROR by them.
+    """
+    return line.endswith(" ERROR") or line.startswith(("ERROR:", "LibClamAV Error:"))
+
+
+def resolve_exit2_status(
+    stdout: str,
+    scanned_files: int,
+    hard_error_lines: list[str],
+    skipped_files: list[str],
+    nonfatal_warnings: list[str],
+    scanned_is_precount: bool = False,
+) -> tuple[ScanStatus, str | None, str | None]:
+    """Classify an exit-2 scan with no detections as benign CLEAN or real ERROR.
+
+    clamscan/clamdscan report exit code 2 even for benign, by-design situations
+    (unreadable files, files exceeding scan limits, truncated archives). The
+    scan is downgraded to CLEAN only when the cause was positively identified
+    as non-fatal (a skipped file, a limit/truncation warning, or the summary's
+    "Total errors: N" line in -i mode), nothing looked like a hard error, AND
+    at least one file was actually scanned. A scan where every file failed is
+    a real ERROR, not a clean result.
+
+    Args:
+        stdout: Full stdout, used to lazily parse "Total errors: N".
+        scanned_files: For clamscan, the summary's "Scanned files" count. For
+            clamdscan (``scanned_is_precount=True``), ClamUI's own pre-count of
+            scan targets, since clamdscan reports no such summary line.
+        hard_error_lines: Genuine-looking error lines from the output.
+        skipped_files: Paths ClamAV could not open/process.
+        nonfatal_warnings: Limit/truncation warnings (partial scans).
+        scanned_is_precount: True when ``scanned_files`` is a pre-count. A
+            pre-count of 0 means counting was skipped, not that nothing was
+            scanned, so the all-failed guard compares failure signals against
+            the pre-count instead of requiring it to be positive.
+
+    Returns:
+        Tuple of ``(status, warning_message, error_message)``.
+    """
+    total_errors: int | None = None
+
+    def get_total_errors() -> int:
+        nonlocal total_errors
+        if total_errors is None:
+            total_errors = parse_total_errors(stdout)
+        return total_errors
+
+    def all_files_failed() -> bool:
+        if not scanned_is_precount:
+            return scanned_files == 0
+        if scanned_files <= 0:
+            return False
+        return len(skipped_files) >= scanned_files or get_total_errors() >= scanned_files
+
+    if not hard_error_lines and (skipped_files or nonfatal_warnings):
+        if all_files_failed():
+            return (ScanStatus.ERROR, None, _("No files could be scanned"))
+        if skipped_files:
+            warning_message = _("{count} file(s) could not be accessed").format(
+                count=len(skipped_files)
+            )
+        else:
+            warning_message = _(
+                "{count} non-fatal warning(s) during scan; some files may "
+                "have been only partially scanned"
+            ).format(count=len(nonfatal_warnings))
+        return (ScanStatus.CLEAN, warning_message, None)
+
+    if not hard_error_lines and get_total_errors() > 0:
+        # -i mode suppresses per-file "Access denied" lines, so the summary's
+        # "Total errors: N" is the only positive signal that exit 2 was caused
+        # by unreadable files, not a scan failure.
+        if all_files_failed():
+            return (ScanStatus.ERROR, None, _("No files could be scanned"))
+        return (
+            ScanStatus.CLEAN,
+            _("{count} file(s) could not be read").format(count=get_total_errors()),
+            None,
+        )
+
+    return (ScanStatus.ERROR, None, None)
 
 
 def cleanup_process(process: subprocess.Popen | None) -> None:

--- a/src/core/scanner_types.py
+++ b/src/core/scanner_types.py
@@ -8,7 +8,7 @@ This module defines the shared data types used by scanner implementations:
 - ScanResult: Dataclass for complete scan results
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 
@@ -94,6 +94,7 @@ class ScanResult:
     skipped_files: list[str] | None = None  # Files that couldn't be scanned (permissions)
     skipped_count: int = 0  # Count of skipped files
     warning_message: str | None = None  # User-friendly warning about skipped files
+    nonfatal_warnings: list[str] = field(default_factory=list)  # Non-fatal ClamAV warning lines
 
     @property
     def is_clean(self) -> bool:
@@ -108,4 +109,4 @@ class ScanResult:
     @property
     def has_warnings(self) -> bool:
         """Check if scan completed with warnings (e.g., skipped files)."""
-        return self.skipped_count > 0
+        return self.skipped_count > 0 or bool(self.nonfatal_warnings)

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-from .utils import is_flatpak, which_host_command, wrap_host_command
+from .utils import get_clean_env, is_flatpak, which_host_command, wrap_host_command
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +155,7 @@ def _check_systemd_available() -> bool:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
             # systemctl --user status returns 0 even if no units
             # It returns non-zero if user session isn't available
@@ -334,6 +335,7 @@ class Scheduler:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode == 0:
@@ -351,6 +353,7 @@ class Scheduler:
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=get_clean_env(),
                 )
 
                 if next_result.returncode == 0:
@@ -381,6 +384,7 @@ class Scheduler:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode == 0:
@@ -547,9 +551,9 @@ class Scheduler:
                 return False
         return path.exists()
 
-    def _get_cli_command_path(self) -> str | None:
+    def _get_cli_command_path(self) -> list[str] | None:
         """
-        Get the path to the clamui-scheduled-scan CLI command.
+        Get the command tokens to invoke the clamui-scheduled-scan CLI.
 
         Searches in order:
         0. Flatpak: use 'flatpak run <app-id>' command
@@ -558,36 +562,38 @@ class Scheduler:
         3. Fallback to module execution with venv's Python
 
         Returns:
-            Path to the CLI command, or None if not found
+            Command as a list of argv tokens, or None if not found. Tokens
+            are kept unsplit so an executable path containing spaces or
+            quotes survives intact (issue #150).
         """
         # 0. In Flatpak, use 'flatpak run --command=' to invoke the CLI from host systemd
         if is_flatpak():
             app_id = os.environ.get("FLATPAK_ID", "io.github.linx_systems.ClamUI")
-            return f"flatpak run --command=clamui-scheduled-scan {app_id}"
+            return ["flatpak", "run", "--command=clamui-scheduled-scan", app_id]
 
         # 1. First try to find it in PATH
         cli_path = which_host_command("clamui-scheduled-scan")
         if cli_path:
-            return cli_path
+            return [cli_path]
 
         # 2. Check well-known venv installation locations for the entry point
         for venv_path in self._get_venv_paths():
             cli_bin = venv_path / "bin" / "clamui-scheduled-scan"
             if self._check_path_exists(cli_bin):
-                return str(cli_bin)
+                return [str(cli_bin)]
 
         # 3. Check well-known venv locations for Python to run the module
         for venv_path in self._get_venv_paths():
             python_bin = venv_path / "bin" / "python"
             if self._check_path_exists(python_bin):
                 # Use the venv's Python with the correct module path
-                return f"{python_bin} -m src.cli.scheduled_scan"
+                return [str(python_bin), "-m", "src.cli.scheduled_scan"]
 
         # 4. Last resort: System Python with correct module path
         # (This likely won't work unless installed system-wide via pip)
         python_path = which_host_command("python3") or which_host_command("python")
         if python_path:
-            return f"{python_path} -m src.cli.scheduled_scan"
+            return [python_path, "-m", "src.cli.scheduled_scan"]
 
         return None
 
@@ -682,9 +688,9 @@ class Scheduler:
             # Ensure systemd user directory exists
             self._systemd_dir.mkdir(parents=True, exist_ok=True)
 
-            # Get CLI command path
-            cli_path = self._get_cli_command_path()
-            if not cli_path:
+            # Get CLI command tokens
+            cli_command = self._get_cli_command_path()
+            if not cli_command:
                 return (False, "Could not find clamui-scheduled-scan command")
 
             # Generate OnCalendar specification
@@ -692,7 +698,7 @@ class Scheduler:
 
             # Create service file
             service_content = self._generate_service_file(
-                cli_path, targets, skip_on_battery, auto_quarantine
+                cli_command, targets, skip_on_battery, auto_quarantine
             )
             service_path = self._systemd_dir / f"{self.SERVICE_NAME}.service"
             service_path.write_text(service_content, encoding="utf-8")
@@ -707,6 +713,7 @@ class Scheduler:
                 wrap_host_command(["systemctl", "--user", "daemon-reload"]),
                 capture_output=True,
                 timeout=10,
+                env=get_clean_env(),
             )
 
             # Enable and start timer
@@ -723,6 +730,7 @@ class Scheduler:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=get_clean_env(),
             )
 
             if result.returncode != 0:
@@ -741,7 +749,7 @@ class Scheduler:
 
     def _generate_service_file(
         self,
-        cli_path: str,
+        cli_command: list[str] | str,
         targets: list[str],
         skip_on_battery: bool,
         auto_quarantine: bool,
@@ -749,32 +757,48 @@ class Scheduler:
         """
         Generate systemd service file content.
 
+        Args:
+            cli_command: CLI invocation as a list of argv tokens (e.g.
+                ['flatpak', 'run', ...]). A bare string is treated as a
+                single executable path and never word-split, so paths
+                containing spaces or quotes stay intact (issue #150).
+            targets: List of paths to scan
+            skip_on_battery: Skip scan when on battery power
+            auto_quarantine: Automatically quarantine threats
+
         Returns:
             Service file content as string
         """
-        # Build command with options
-        # cli_path may be a multi-token command (e.g. 'flatpak run ...' or
-        # '<python> -m src.cli.scheduled_scan'); quote each token separately
-        # so it stays an executable ExecStart rather than one quoted blob.
-        # shlex.quote() on each token still prevents injection via malicious paths.
-        exec_cmd = " ".join(shlex.quote(tok) for tok in shlex.split(cli_path))
-        if skip_on_battery:
-            exec_cmd += " --skip-on-battery"
-        if auto_quarantine:
-            exec_cmd += " --auto-quarantine"
-        for target in targets:
-            exec_cmd += f" --target {shlex.quote(target)}"
+        if isinstance(cli_command, str):
+            cli_command = [cli_command]
+        # Quote each argv token separately so multi-token commands (e.g.
+        # 'flatpak run ...') stay an executable ExecStart rather than one
+        # quoted blob, while shlex.quote() still prevents injection via
+        # malicious paths.
+        exec_cmd = " ".join(shlex.quote(tok) for tok in cli_command)
 
         # Neutralize systemd environment-variable expansion in user-supplied
         # paths.  Unlike a shell, systemd expands "${VAR}" (and a standalone
         # "$VAR" argument) even inside single quotes -- shlex.quote() does NOT
         # protect against this -- so a target such as "/data/${HOME}/x" would
         # be silently rewritten to a wrong/empty path at scan time.  The
-        # documented escape for a literal dollar sign is "$$".
-        exec_cmd = exec_cmd.replace("$", "$$")
+        # documented escape for a literal dollar sign is "$$".  systemd does
+        # NOT variable-expand the executable word, so only the argument
+        # portion is escaped; doubling '$' in argv[0] would corrupt an
+        # executable path containing a literal '$'.
+        arg_str = ""
+        if skip_on_battery:
+            arg_str += " --skip-on-battery"
+        if auto_quarantine:
+            arg_str += " --auto-quarantine"
+        for target in targets:
+            arg_str += f" --target {shlex.quote(target)}"
+        exec_cmd += arg_str.replace("$", "$$")
 
         # Escape literal '%' so systemd does not interpret it as a specifier
-        # (e.g. legitimate directory names may contain '%').
+        # (e.g. legitimate directory names may contain '%').  Specifier
+        # expansion covers the whole line including the executable word, so
+        # this stays whole-line.
         exec_cmd = exec_cmd.replace("%", "%%")
 
         return f"""[Unit]
@@ -830,20 +854,25 @@ WantedBy=timers.target
             Tuple of (success, error_message)
         """
         try:
-            # Get CLI command path
-            cli_path = self._get_cli_command_path()
-            if not cli_path:
+            # Get CLI command tokens
+            cli_command = self._get_cli_command_path()
+            if not cli_command:
                 return (False, "Could not find clamui-scheduled-scan command")
+            if isinstance(cli_command, str):
+                # A bare string is one executable path; never word-split it,
+                # or a path containing spaces would exec the wrong file
+                # (issue #150).
+                cli_command = [cli_command]
 
             # Generate cron time specification
             cron_time = self._generate_crontab_entry(frequency, time, day_of_week, day_of_month)
 
             # Build command
-            # cli_path may be a multi-token command (e.g. 'flatpak run ...' or
-            # '<python> -m src.cli.scheduled_scan'); quote each token separately
-            # so it stays an executable command rather than one quoted blob.
-            # shlex.quote() on each token still prevents injection via malicious paths.
-            cron_cmd = " ".join(shlex.quote(tok) for tok in shlex.split(cli_path))
+            # Quote each argv token separately so multi-token commands (e.g.
+            # 'flatpak run ...') stay an executable command rather than one
+            # quoted blob, while shlex.quote() still prevents injection via
+            # malicious paths.
+            cron_cmd = " ".join(shlex.quote(tok) for tok in cli_command)
             if skip_on_battery:
                 cron_cmd += " --skip-on-battery"
             if auto_quarantine:
@@ -864,6 +893,7 @@ WantedBy=timers.target
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode == 0:
@@ -910,6 +940,7 @@ WantedBy=timers.target
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode != 0:
@@ -964,6 +995,7 @@ WantedBy=timers.target
                 ),
                 capture_output=True,
                 timeout=10,
+                env=get_clean_env(),
             )
 
             # Remove files
@@ -980,6 +1012,7 @@ WantedBy=timers.target
                 wrap_host_command(["systemctl", "--user", "daemon-reload"]),
                 capture_output=True,
                 timeout=10,
+                env=get_clean_env(),
             )
 
             return (True, None)
@@ -1007,6 +1040,7 @@ WantedBy=timers.target
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode != 0:
@@ -1045,11 +1079,15 @@ WantedBy=timers.target
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=get_clean_env(),
                 )
             else:
                 # Remove crontab entirely if empty
                 result = subprocess.run(
-                    wrap_host_command(["crontab", "-r"]), capture_output=True, timeout=5
+                    wrap_host_command(["crontab", "-r"]),
+                    capture_output=True,
+                    timeout=5,
+                    env=get_clean_env(),
                 )
 
             if result.returncode != 0:

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -749,7 +749,7 @@ class Scheduler:
 
     def _generate_service_file(
         self,
-        cli_command: list[str] | str,
+        cli_command: list[str],
         targets: list[str],
         skip_on_battery: bool,
         auto_quarantine: bool,
@@ -759,9 +759,7 @@ class Scheduler:
 
         Args:
             cli_command: CLI invocation as a list of argv tokens (e.g.
-                ['flatpak', 'run', ...]). A bare string is treated as a
-                single executable path and never word-split, so paths
-                containing spaces or quotes stay intact (issue #150).
+                ['flatpak', 'run', ...]).
             targets: List of paths to scan
             skip_on_battery: Skip scan when on battery power
             auto_quarantine: Automatically quarantine threats
@@ -769,8 +767,6 @@ class Scheduler:
         Returns:
             Service file content as string
         """
-        if isinstance(cli_command, str):
-            cli_command = [cli_command]
         # Quote each argv token separately so multi-token commands (e.g.
         # 'flatpak run ...') stay an executable ExecStart rather than one
         # quoted blob, while shlex.quote() still prevents injection via
@@ -858,11 +854,6 @@ WantedBy=timers.target
             cli_command = self._get_cli_command_path()
             if not cli_command:
                 return (False, "Could not find clamui-scheduled-scan command")
-            if isinstance(cli_command, str):
-                # A bare string is one executable path; never word-split it,
-                # or a path containing spaces would exec the wrong file
-                # (issue #150).
-                cli_command = [cli_command]
 
             # Generate cron time specification
             cron_time = self._generate_crontab_entry(frequency, time, day_of_week, day_of_month)

--- a/src/core/updater.py
+++ b/src/core/updater.py
@@ -262,6 +262,7 @@ class FreshclamUpdater:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
 
             if result.returncode == 0:
@@ -282,6 +283,7 @@ class FreshclamUpdater:
                         capture_output=True,
                         text=True,
                         timeout=30,
+                        env=get_clean_env(),
                     )
                     if elevated_result.returncode == 0:
                         logger.info("Sent SIGUSR1 to freshclam via pkexec (PID %s)", pid)

--- a/src/core/updater.py
+++ b/src/core/updater.py
@@ -177,6 +177,7 @@ class FreshclamUpdater:
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=get_clean_env(),
                 )
 
                 if result.returncode == 0 and result.stdout.strip() == "active":
@@ -187,6 +188,7 @@ class FreshclamUpdater:
                             capture_output=True,
                             text=True,
                             timeout=5,
+                            env=get_clean_env(),
                         )
                         if pid_result.returncode == 0:
                             pid = pid_result.stdout.strip().split()[0]  # Take first PID
@@ -243,6 +245,7 @@ class FreshclamUpdater:
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=get_clean_env(),
                 )
                 if pid_result.returncode == 0:
                     pid = pid_result.stdout.strip().split()[0]
@@ -321,6 +324,7 @@ class FreshclamUpdater:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                env=get_clean_env(),
             )
             if pid_result.returncode == 0 and pid_result.stdout.strip():
                 pid = pid_result.stdout.strip().split()[0]

--- a/src/ui/audit_view.py
+++ b/src/ui/audit_view.py
@@ -819,7 +819,7 @@ class AuditView(Gtk.Box):
         """
         import subprocess
 
-        from ..core.flatpak import is_flatpak
+        from ..core.flatpak import get_clean_env, is_flatpak
 
         # Sentinel: instead of spawning a subprocess, kick off Portmaster's
         # third-party authorization flow. Handled here (rather than in a
@@ -830,11 +830,15 @@ class AuditView(Gtk.Box):
 
         try:
             cmd = ["flatpak-spawn", "--host", command] if is_flatpak() else [command]
+            # env: gufw/firewall-config are host Python/GTK scripts; a leaked
+            # AppImage PYTHONHOME kills them instantly and stderr is DEVNULL
+            # (issue #155 residual).
             subprocess.Popen(
                 cmd,
                 start_new_session=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=get_clean_env(),
             )
         except FileNotFoundError:
             logger.warning("Could not launch: %s (not found)", command)

--- a/src/ui/preferences/base.py
+++ b/src/ui/preferences/base.py
@@ -545,7 +545,7 @@ class PreferencesPageMixin:
             )
             return
 
-        from ...core.flatpak import is_flatpak
+        from ...core.flatpak import get_clean_env, is_flatpak
 
         if is_flatpak():
             try:
@@ -586,6 +586,7 @@ class PreferencesPageMixin:
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,
+                    env=get_clean_env(),
                 )
             except Exception as e:
                 self._show_simple_dialog(

--- a/src/ui/preferences/scanner_page.py
+++ b/src/ui/preferences/scanner_page.py
@@ -28,6 +28,7 @@ from ...core.clamav_config import megabytes_to_size_value, size_value_to_megabyt
 from ...core.clamav_detection import detect_clamd_conf_path
 from ...core.flatpak import (
     format_flatpak_portal_path,
+    get_clean_env,
     is_flatpak,
     is_portal_path,
     resolve_portal_path,
@@ -524,6 +525,7 @@ class ScannerPage(PreferencesPageMixin):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
+                env=get_clean_env(),
             )
         except Exception as e:
             # Show error dialog if opening fails

--- a/src/ui/scan/scan_controller.py
+++ b/src/ui/scan/scan_controller.py
@@ -18,6 +18,7 @@ from enum import Enum
 
 from gi.repository import GLib
 
+from ...core.result_formatters import compose_scan_warning
 from ...core.scanner import Scanner, ScanProgress, ScanResult, ScanStatus
 from ...core.settings_manager import SettingsManager
 
@@ -49,15 +50,7 @@ class AggregatedResult:
     def to_scan_result(self, paths: list[str]) -> ScanResult:
         """Convert to ScanResult for dialog compatibility."""
         exit_code = 1 if self.status == ScanStatus.INFECTED else (2 if self.error_messages else 0)
-        # Re-derive the single-target phrasing when files were skipped,
-        # otherwise join the distinct per-target messages (e.g. non-fatal
-        # scanner warnings) — same composition as the legacy ScanView.
-        if self.skipped_count > 0:
-            warning_message = f"{self.skipped_count} file(s) could not be accessed"
-        elif self.warning_messages:
-            warning_message = "; ".join(self.warning_messages)
-        else:
-            warning_message = None
+        warning_message = compose_scan_warning(self.skipped_count, self.warning_messages)
         return ScanResult(
             status=self.status,
             path=", ".join(paths) if len(paths) > 1 else paths[0] if paths else "",
@@ -232,12 +225,21 @@ class ScanController:
             if not result.error_messages:
                 result.error_messages.append(str(exc))
         finally:
-            self._state = ScanState.IDLE
-            if self._on_state_change:
-                GLib.idle_add(self._on_state_change, self._state)
+            final_result = result.to_scan_result(paths)
 
-            if self._on_complete:
-                GLib.idle_add(self._on_complete, result.to_scan_result(paths))
+            def _finalize():
+                # Runs on the main thread: flipping to IDLE here (rather than
+                # on the worker thread) keeps is_scanning True until callers
+                # of start_scan — which is main-thread-only — can no longer
+                # race a second worker against this one.
+                self._state = ScanState.IDLE
+                if self._on_state_change:
+                    self._on_state_change(self._state)
+                if self._on_complete:
+                    self._on_complete(final_result)
+                return False
+
+            GLib.idle_add(_finalize)
 
     def _aggregate_result(self, agg: AggregatedResult, scan: ScanResult):
         """Add scan result to aggregated total."""
@@ -255,12 +257,18 @@ class ScanController:
         agg.total_infected += scan.infected_count
         agg.infected_files.extend(scan.infected_files)
         agg.threat_details.extend(scan.threat_details)
+        seen_skipped = set(agg.skipped_files)
         for skipped in scan.skipped_files or []:
-            if skipped not in agg.skipped_files:
+            if skipped not in seen_skipped:
+                seen_skipped.add(skipped)
                 agg.skipped_files.append(skipped)
-        agg.skipped_count += scan.skipped_count
+        # Keep the count in sync with the deduplicated list so overlapping
+        # targets never over-report skipped files.
+        agg.skipped_count = len(agg.skipped_files)
+        seen_warnings = set(agg.nonfatal_warnings)
         for warning in scan.nonfatal_warnings or []:
-            if warning not in agg.nonfatal_warnings:
+            if warning not in seen_warnings:
+                seen_warnings.add(warning)
                 agg.nonfatal_warnings.append(warning)
         if scan.warning_message and scan.warning_message not in agg.warning_messages:
             agg.warning_messages.append(scan.warning_message)

--- a/src/ui/scan/scan_controller.py
+++ b/src/ui/scan/scan_controller.py
@@ -41,10 +41,23 @@ class AggregatedResult:
     infected_files: list[str] = field(default_factory=list)
     threat_details: list = field(default_factory=list)
     error_messages: list[str] = field(default_factory=list)
+    skipped_files: list[str] = field(default_factory=list)
+    skipped_count: int = 0
+    nonfatal_warnings: list[str] = field(default_factory=list)
+    warning_messages: list[str] = field(default_factory=list)
 
     def to_scan_result(self, paths: list[str]) -> ScanResult:
         """Convert to ScanResult for dialog compatibility."""
         exit_code = 1 if self.status == ScanStatus.INFECTED else (2 if self.error_messages else 0)
+        # Re-derive the single-target phrasing when files were skipped,
+        # otherwise join the distinct per-target messages (e.g. non-fatal
+        # scanner warnings) — same composition as the legacy ScanView.
+        if self.skipped_count > 0:
+            warning_message = f"{self.skipped_count} file(s) could not be accessed"
+        elif self.warning_messages:
+            warning_message = "; ".join(self.warning_messages)
+        else:
+            warning_message = None
         return ScanResult(
             status=self.status,
             path=", ".join(paths) if len(paths) > 1 else paths[0] if paths else "",
@@ -57,6 +70,10 @@ class AggregatedResult:
             infected_count=self.total_infected,
             error_message="; ".join(self.error_messages) if self.error_messages else None,
             threat_details=self.threat_details,
+            skipped_files=self.skipped_files,
+            skipped_count=self.skipped_count,
+            warning_message=warning_message,
+            nonfatal_warnings=self.nonfatal_warnings,
         )
 
 
@@ -224,11 +241,7 @@ class ScanController:
 
     def _aggregate_result(self, agg: AggregatedResult, scan: ScanResult):
         """Add scan result to aggregated total."""
-        agg.total_files += scan.scanned_files
-        agg.total_dirs += scan.scanned_dirs
-        agg.total_infected += scan.infected_count
-        agg.infected_files.extend(scan.infected_files)
-        agg.threat_details.extend(scan.threat_details)
+        self._aggregate_partial(agg, scan)
 
         if scan.status == ScanStatus.ERROR and scan.error_message:
             agg.error_messages.append(scan.error_message)
@@ -242,6 +255,15 @@ class ScanController:
         agg.total_infected += scan.infected_count
         agg.infected_files.extend(scan.infected_files)
         agg.threat_details.extend(scan.threat_details)
+        for skipped in scan.skipped_files or []:
+            if skipped not in agg.skipped_files:
+                agg.skipped_files.append(skipped)
+        agg.skipped_count += scan.skipped_count
+        for warning in scan.nonfatal_warnings or []:
+            if warning not in agg.nonfatal_warnings:
+                agg.nonfatal_warnings.append(warning)
+        if scan.warning_message and scan.warning_message not in agg.warning_messages:
+            agg.warning_messages.append(scan.warning_message)
 
     def _create_progress_callback(self):
         """Create throttled progress callback."""

--- a/src/ui/scan/scan_view.py
+++ b/src/ui/scan/scan_view.py
@@ -23,6 +23,7 @@ from gi.repository import Adw, Gdk, Gtk
 
 from ...core.i18n import _
 from ...core.quarantine import QuarantineManager
+from ...core.result_formatters import clean_scan_status_message
 from ...core.scanner import Scanner, ScanResult, ScanStatus
 from ...core.settings_manager import SettingsManager
 from ...core.utils import format_scan_path, is_flatpak
@@ -251,19 +252,7 @@ class ScanView(Gtk.Box):
                 StatusLevel.WARNING,
             )
         elif result.status == ScanStatus.CLEAN:
-            if result.skipped_count > 0:
-                msg = _("Scan complete - No threats found ({count} file(s) not accessible)").format(
-                    count=result.skipped_count
-                )
-            elif result.warning_message:
-                # Warnings without a skipped-file count (e.g. non-fatal scanner
-                # warnings) — never render a bare "0 file(s)" message.
-                msg = _("Scan complete - No threats found ({warning})").format(
-                    warning=result.warning_message
-                )
-            else:
-                msg = _("Scan complete - No threats found")
-            self._show_banner(msg, StatusLevel.SUCCESS)
+            self._show_banner(clean_scan_status_message(result), StatusLevel.SUCCESS)
         elif result.status == ScanStatus.CANCELLED:
             self._show_banner(_("Scan cancelled"), StatusLevel.WARNING)
         else:

--- a/src/ui/scan/scan_view.py
+++ b/src/ui/scan/scan_view.py
@@ -60,19 +60,23 @@ class ScanView(Gtk.Box):
         self,
         settings_manager: SettingsManager | None = None,
         quarantine_manager: QuarantineManager | None = None,
+        log_manager=None,
         **kwargs,
     ):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, **kwargs)
 
         self._settings_manager = settings_manager
         self._quarantine_manager = quarantine_manager or QuarantineManager()
+        self._log_manager = log_manager
         self._current_result: ScanResult | None = None
         self._scan_state_callback = None
         self._eicar_temp_path = ""
 
         self._setup_css()
-        self._setup_ui()
+        # The controller creates the Scanner that _setup_ui's backend
+        # indicator reads, so it must be wired first.
         self._setup_controller()
+        self._setup_ui()
 
     def _setup_css(self):
         css_provider = Gtk.CssProvider()
@@ -135,7 +139,9 @@ class ScanView(Gtk.Box):
         self._setup_drop_target()
 
     def _setup_controller(self):
-        self._scanner = Scanner(settings_manager=self._settings_manager)
+        self._scanner = Scanner(
+            log_manager=self._log_manager, settings_manager=self._settings_manager
+        )
 
         self._controller = ScanController(self._scanner, self._settings_manager)
         self._controller.set_callbacks(
@@ -245,11 +251,18 @@ class ScanView(Gtk.Box):
                 StatusLevel.WARNING,
             )
         elif result.status == ScanStatus.CLEAN:
-            msg = _("Scan complete - No threats found")
-            if result.has_warnings:
+            if result.skipped_count > 0:
                 msg = _("Scan complete - No threats found ({count} file(s) not accessible)").format(
                     count=result.skipped_count
                 )
+            elif result.warning_message:
+                # Warnings without a skipped-file count (e.g. non-fatal scanner
+                # warnings) — never render a bare "0 file(s)" message.
+                msg = _("Scan complete - No threats found ({warning})").format(
+                    warning=result.warning_message
+                )
+            else:
+                msg = _("Scan complete - No threats found")
             self._show_banner(msg, StatusLevel.SUCCESS)
         elif result.status == ScanStatus.CANCELLED:
             self._show_banner(_("Scan cancelled"), StatusLevel.WARNING)
@@ -391,6 +404,11 @@ class ScanView(Gtk.Box):
 
     # --- Public API ---
 
+    @property
+    def is_scanning(self) -> bool:
+        """Whether a scan is currently in progress."""
+        return self._controller.is_scanning
+
     def set_scan_state_changed_callback(self, callback):
         self._scan_state_callback = callback
 
@@ -408,6 +426,9 @@ class ScanView(Gtk.Box):
 
     def _set_selected_path(self, path: str):
         self._target_selector.set_paths([path])
+
+    def _replace_selected_paths(self, paths: list[str]) -> None:
+        self._target_selector.set_paths(paths)
 
     def _start_scan_public(self):
         self._start_scan()

--- a/src/ui/scan_results_dialog.py
+++ b/src/ui/scan_results_dialog.py
@@ -183,10 +183,18 @@ class ScanResultsDialog(Adw.Window):
         # Set title based on result status
         if self._scan_result.status == ScanStatus.CLEAN:
             expander.set_title(_("Scan Complete"))
-            if self._scan_result.has_warnings:
+            if self._scan_result.skipped_count > 0:
                 expander.set_subtitle(
                     _("No threats found ({count} file(s) not accessible)").format(
                         count=self._scan_result.skipped_count
+                    )
+                )
+            elif self._scan_result.warning_message:
+                # Warnings without a skipped-file count (e.g. non-fatal scanner
+                # warnings) — never render a bare "0 file(s)" subtitle.
+                expander.set_subtitle(
+                    _("No threats found ({warning})").format(
+                        warning=GLib.markup_escape_text(self._scan_result.warning_message)
                     )
                 )
             else:

--- a/src/ui/scan_view.py
+++ b/src/ui/scan_view.py
@@ -17,6 +17,7 @@ from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
 from ..core.i18n import _, ngettext
 from ..core.quarantine import QuarantineManager
+from ..core.result_formatters import clean_scan_status_message, compose_scan_warning
 from ..core.scanner import Scanner, ScanProgress, ScanResult, ScanStatus
 from ..core.utils import (
     format_scan_path,
@@ -2036,8 +2037,8 @@ class ScanView(Gtk.Box):
             all_stderr: list[str] = []
             all_skipped_files: list[str] = []
             seen_skipped_files: set[str] = set()
-            total_skipped_count = 0
             all_nonfatal_warnings: list[str] = []
+            seen_nonfatal_warnings: set[str] = set()
             all_warning_messages: list[str] = []
             has_errors = False
             error_messages: list[str] = []
@@ -2095,11 +2096,9 @@ class ScanView(Gtk.Box):
                     if skipped not in seen_skipped_files:
                         seen_skipped_files.add(skipped)
                         all_skipped_files.append(skipped)
-                total_skipped_count += result.skipped_count
-                # nonfatal_warnings is a newer ScanResult field; read it
-                # defensively so aggregation works with or without it.
-                for warning in getattr(result, "nonfatal_warnings", None) or []:
-                    if warning not in all_nonfatal_warnings:
+                for warning in result.nonfatal_warnings:
+                    if warning not in seen_nonfatal_warnings:
+                        seen_nonfatal_warnings.add(warning)
                         all_nonfatal_warnings.append(warning)
                 if result.warning_message and result.warning_message not in all_warning_messages:
                     all_warning_messages.append(result.warning_message)
@@ -2131,15 +2130,10 @@ class ScanView(Gtk.Box):
                 else:
                     final_status = ScanStatus.CLEAN
 
-            # Compose the aggregated warning: re-derive the single-target
-            # phrasing when files were skipped, otherwise join the distinct
-            # per-target messages (e.g. non-fatal scanner warnings).
-            if total_skipped_count > 0:
-                aggregated_warning = f"{total_skipped_count} file(s) could not be accessed"
-            elif all_warning_messages:
-                aggregated_warning = "; ".join(all_warning_messages)
-            else:
-                aggregated_warning = None
+            # The count must match the deduplicated list: overlapping targets
+            # can report the same skipped file more than once.
+            total_skipped_count = len(all_skipped_files)
+            aggregated_warning = compose_scan_warning(total_skipped_count, all_warning_messages)
 
             # Build aggregated result
             aggregated_result = ScanResult(
@@ -2157,9 +2151,8 @@ class ScanView(Gtk.Box):
                 skipped_files=all_skipped_files,
                 skipped_count=total_skipped_count,
                 warning_message=aggregated_warning,
+                nonfatal_warnings=all_nonfatal_warnings,
             )
-            if hasattr(aggregated_result, "nonfatal_warnings"):
-                aggregated_result.nonfatal_warnings = all_nonfatal_warnings
 
             # Schedule UI update on main thread
             GLib.idle_add(self._on_scan_complete, aggregated_result)
@@ -2275,20 +2268,7 @@ class ScanView(Gtk.Box):
             )
         elif result.status == ScanStatus.CLEAN:
             self._show_view_results(0)
-            if result.skipped_count > 0:
-                # Clean but with warnings about skipped files
-                status_message = _(
-                    "Scan complete - No threats found ({count} file(s) not accessible)"
-                ).format(count=result.skipped_count)
-            elif result.warning_message:
-                # Warnings without a skipped-file count (e.g. non-fatal scanner
-                # warnings) — never render a bare "0 file(s)" message.
-                status_message = _("Scan complete - No threats found ({warning})").format(
-                    warning=result.warning_message
-                )
-            else:
-                status_message = _("Scan complete - No threats found")
-            self._set_status_message(status_message, StatusLevel.SUCCESS)
+            self._set_status_message(clean_scan_status_message(result), StatusLevel.SUCCESS)
         elif result.status == ScanStatus.CANCELLED:
             self._show_view_results(result.infected_count)
             self._set_status_message(_("Scan cancelled"), StatusLevel.WARNING)

--- a/src/ui/scan_view.py
+++ b/src/ui/scan_view.py
@@ -1988,7 +1988,12 @@ class ScanView(Gtk.Box):
         Scans each selected path sequentially and aggregates results.
         """
         try:
-            if not self._selected_paths:
+            # Snapshot the targets: self._selected_paths can be repopulated
+            # from the main thread (e.g. a second CLI/file-manager invocation)
+            # while this worker is running; iterating the live list would
+            # corrupt the scan session.
+            targets = list(self._selected_paths)
+            if not targets:
                 # Should not happen, but handle gracefully
                 result = ScanResult(
                     status=ScanStatus.ERROR,
@@ -2029,15 +2034,20 @@ class ScanView(Gtk.Box):
             all_threat_details: list = []
             all_stdout: list[str] = []
             all_stderr: list[str] = []
+            all_skipped_files: list[str] = []
+            seen_skipped_files: set[str] = set()
+            total_skipped_count = 0
+            all_nonfatal_warnings: list[str] = []
+            all_warning_messages: list[str] = []
             has_errors = False
             error_messages: list[str] = []
             final_status = ScanStatus.CLEAN
 
-            target_count = len(self._selected_paths)
+            target_count = len(targets)
             backend_override = self._scan_backend_override
             daemon_force_stream = self._scan_daemon_force_stream
 
-            for idx, target_path in enumerate(self._selected_paths, start=1):
+            for idx, target_path in enumerate(targets, start=1):
                 # Check if cancel all was requested before starting next target
                 if self._cancel_all_requested:
                     logger.info(f"Cancel all requested, skipping target {idx}/{target_count}")
@@ -2075,23 +2085,29 @@ class ScanView(Gtk.Box):
                     daemon_force_stream=daemon_force_stream,
                 )
 
-                # Check if scan was cancelled (either this target or cancel all)
-                if result.status == ScanStatus.CANCELLED or self._cancel_all_requested:
-                    # Aggregate partial results from this cancelled target
-                    total_scanned_files += result.scanned_files
-                    total_scanned_dirs += result.scanned_dirs
-                    total_infected_count += result.infected_count
-                    all_infected_files.extend(result.infected_files)
-                    all_threat_details.extend(result.threat_details)
-                    final_status = ScanStatus.CANCELLED
-                    break
-
-                # Aggregate results
+                # Aggregate results (also partial results from a cancelled target)
                 total_scanned_files += result.scanned_files
                 total_scanned_dirs += result.scanned_dirs
                 total_infected_count += result.infected_count
                 all_infected_files.extend(result.infected_files)
                 all_threat_details.extend(result.threat_details)
+                for skipped in result.skipped_files or []:
+                    if skipped not in seen_skipped_files:
+                        seen_skipped_files.add(skipped)
+                        all_skipped_files.append(skipped)
+                total_skipped_count += result.skipped_count
+                # nonfatal_warnings is a newer ScanResult field; read it
+                # defensively so aggregation works with or without it.
+                for warning in getattr(result, "nonfatal_warnings", None) or []:
+                    if warning not in all_nonfatal_warnings:
+                        all_nonfatal_warnings.append(warning)
+                if result.warning_message and result.warning_message not in all_warning_messages:
+                    all_warning_messages.append(result.warning_message)
+
+                # Check if scan was cancelled (either this target or cancel all)
+                if result.status == ScanStatus.CANCELLED or self._cancel_all_requested:
+                    final_status = ScanStatus.CANCELLED
+                    break
 
                 if result.stdout:
                     all_stdout.append(f"=== {target_path} ===\n{result.stdout}")
@@ -2115,12 +2131,20 @@ class ScanView(Gtk.Box):
                 else:
                     final_status = ScanStatus.CLEAN
 
+            # Compose the aggregated warning: re-derive the single-target
+            # phrasing when files were skipped, otherwise join the distinct
+            # per-target messages (e.g. non-fatal scanner warnings).
+            if total_skipped_count > 0:
+                aggregated_warning = f"{total_skipped_count} file(s) could not be accessed"
+            elif all_warning_messages:
+                aggregated_warning = "; ".join(all_warning_messages)
+            else:
+                aggregated_warning = None
+
             # Build aggregated result
             aggregated_result = ScanResult(
                 status=final_status,
-                path=(
-                    ", ".join(self._selected_paths) if target_count > 1 else self._selected_paths[0]
-                ),
+                path=(", ".join(targets) if target_count > 1 else targets[0]),
                 stdout="\n\n".join(all_stdout),
                 stderr="\n\n".join(all_stderr),
                 exit_code=(1 if final_status == ScanStatus.INFECTED else (2 if has_errors else 0)),
@@ -2130,7 +2154,12 @@ class ScanView(Gtk.Box):
                 infected_count=total_infected_count,
                 error_message="; ".join(error_messages) if error_messages else None,
                 threat_details=all_threat_details,
+                skipped_files=all_skipped_files,
+                skipped_count=total_skipped_count,
+                warning_message=aggregated_warning,
             )
+            if hasattr(aggregated_result, "nonfatal_warnings"):
+                aggregated_result.nonfatal_warnings = all_nonfatal_warnings
 
             # Schedule UI update on main thread
             GLib.idle_add(self._on_scan_complete, aggregated_result)
@@ -2246,11 +2275,17 @@ class ScanView(Gtk.Box):
             )
         elif result.status == ScanStatus.CLEAN:
             self._show_view_results(0)
-            if result.has_warnings:
+            if result.skipped_count > 0:
                 # Clean but with warnings about skipped files
                 status_message = _(
                     "Scan complete - No threats found ({count} file(s) not accessible)"
                 ).format(count=result.skipped_count)
+            elif result.warning_message:
+                # Warnings without a skipped-file count (e.g. non-fatal scanner
+                # warnings) — never render a bare "0 file(s)" message.
+                status_message = _("Scan complete - No threats found ({warning})").format(
+                    warning=result.warning_message
+                )
             else:
                 status_message = _("Scan complete - No threats found")
             self._set_status_message(status_message, StatusLevel.SUCCESS)
@@ -2399,6 +2434,11 @@ class ScanView(Gtk.Box):
     def set_scan_state_changed_callback(self, callback):
         """Alias for set_on_scan_state_changed for backwards compatibility."""
         self.set_on_scan_state_changed(callback)
+
+    @property
+    def is_scanning(self) -> bool:
+        """Whether a scan is currently in progress."""
+        return self._is_scanning
 
     def get_selected_profile(self) -> "ScanProfile | None":
         """Return the currently selected scan profile."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ This file provides:
 - Locale forcing (LANGUAGE=C) to ensure English gettext output
 """
 
+import contextlib
 import gettext
 import os
 import sys
@@ -220,6 +221,34 @@ def _clear_src_modules():
     modules_to_remove = [mod for mod in sys.modules if mod.startswith("src.")]
     for mod in modules_to_remove:
         del sys.modules[mod]
+
+
+@contextlib.contextmanager
+def preserve_displaced_modules(match=None):
+    """Snapshot matching sys.modules entries and restore them on exit.
+
+    Test modules that clear or mock src.* (or gi/matplotlib) modules must put
+    the ORIGINAL module objects back afterwards: other test modules bind src
+    symbols at collection time, and patching a re-imported module while
+    calling a stale reference makes assertions silently miss (see the
+    tests/cli/test_scan_cmd.py pollution this pattern fixed). Use this instead
+    of hand-rolling the snapshot/restore idiom.
+
+    Args:
+        match: Predicate on the module name; defaults to src.* modules.
+    """
+    if match is None:
+
+        def match(name):
+            return name.startswith("src.")
+
+    snapshot = {name: module for name, module in sys.modules.items() if match(name)}
+    try:
+        yield
+    finally:
+        for name in [mod for mod in sys.modules if match(mod)]:
+            del sys.modules[name]
+        sys.modules.update(snapshot)
 
 
 # =============================================================================

--- a/tests/core/test_daemon_scanner.py
+++ b/tests/core/test_daemon_scanner.py
@@ -296,7 +296,7 @@ Infected files: 1
 /home/user/a.txt: File path check failure: Permission denied. ERROR
 /home/user/b.txt: File path check failure: Permission denied. ERROR
 """
-        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=2, dir_count=0)
+        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=3, dir_count=0)
 
         assert result.status == scan_status_class.CLEAN
         assert result.infected_count == 0
@@ -313,7 +313,7 @@ Infected files: 1
 /home/user/a.txt: File path check failure: Permission denied. ERROR
 /home/user/a.txt: File path check failure: Permission denied. ERROR
 """
-        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=1, dir_count=0)
+        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=2, dir_count=0)
 
         assert result.status == scan_status_class.CLEAN
         assert result.skipped_count == 1
@@ -331,7 +331,7 @@ LibClamAV Warning: cli_realpath: Invalid arguments.
 WARNING: /home/user/.cache/steam_pipe: Not supported file type
 LibClamAV Warning: cli_realpath: Invalid arguments.
 """
-        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=2, dir_count=0)
+        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=3, dir_count=0)
 
         assert result.status == scan_status_class.CLEAN
         assert result.infected_count == 0
@@ -341,6 +341,48 @@ LibClamAV Warning: cli_realpath: Invalid arguments.
             "/home/user/.cache/steam_pipe",
         ]
         assert result.warning_message == "2 file(s) could not be accessed"
+
+    def test_parse_results_all_files_skipped_is_error(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """Exit 2 where every pre-counted file was inaccessible must not report CLEAN."""
+        scanner = daemon_scanner_class()
+
+        stdout = "".join(f"/root/secret{i}.txt: Access denied. ERROR\n" for i in range(1, 6))
+        result = scanner._parse_results("/root", stdout, "", 2, file_count=5, dir_count=1)
+
+        assert result.status == scan_status_class.ERROR
+        assert result.error_message == "No files could be scanned"
+        assert result.skipped_count == 5
+
+    def test_parse_results_all_skipped_without_precount_still_downgrades(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """With counting disabled (file_count=0) skip warnings still downgrade to CLEAN."""
+        scanner = daemon_scanner_class()
+
+        stdout = "/root/secret.txt: Access denied. ERROR\n"
+        result = scanner._parse_results("/root", stdout, "", 2, file_count=0, dir_count=0)
+
+        assert result.status == scan_status_class.CLEAN
+        assert result.skipped_files == ["/root/secret.txt"]
+        assert result.warning_message == "1 file(s) could not be accessed"
+
+    def test_parse_results_total_errors_covering_precount_is_error(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """'Total errors' matching the pre-count means every file failed -> ERROR."""
+        scanner = daemon_scanner_class()
+
+        stdout = """
+----------- SCAN SUMMARY -----------
+Infected files: 0
+Total errors: 4
+"""
+        result = scanner._parse_results("/root", stdout, "", 2, file_count=4, dir_count=1)
+
+        assert result.status == scan_status_class.ERROR
+        assert result.error_message == "No files could be scanned"
 
     def test_parse_results_exit_code_2_with_detection_is_infected(
         self, daemon_scanner_class, scan_status_class

--- a/tests/core/test_daemon_scanner.py
+++ b/tests/core/test_daemon_scanner.py
@@ -358,6 +358,129 @@ LibClamAV Warning: cli_realpath: Invalid arguments.
         assert result.infected_count == 1
         assert "/home/user/eicar.txt" in result.infected_files
 
+    def test_parse_results_issue_149_warning_lines_exit_2_clean(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """Regression for issue #149: the exact benign LibClamAV warnings from the
+        report must not flip an exit-2 daemon scan to ERROR."""
+        scanner = daemon_scanner_class()
+
+        stdout = """
+----------- SCAN SUMMARY -----------
+Infected files: 0
+"""
+        stderr = (
+            "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN\n"
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits - "
+            "only scanning 105906176 bytes\n"
+        )
+
+        result = scanner._parse_results(
+            "/home/user", stdout, stderr, 2, file_count=100, dir_count=3
+        )
+
+        assert result.status == scan_status_class.CLEAN
+        assert result.error_message is None
+        assert result.nonfatal_warnings == [
+            "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN",
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits - "
+            "only scanning 105906176 bytes",
+        ]
+        assert result.has_warnings is True
+        assert result.warning_message == (
+            "2 non-fatal warning(s) during scan; some files may have been only partially scanned"
+        )
+
+    def test_parse_results_exit_0_with_stray_warning_stays_clean(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """A stray unrecognized warning line must not override the daemon's exit 0."""
+        scanner = daemon_scanner_class()
+
+        stdout = """
+/home/user/test.txt: OK
+
+----------- SCAN SUMMARY -----------
+Infected files: 0
+"""
+        stderr = "LibClamAV Warning: something novel happened\n"
+
+        result = scanner._parse_results("/home/user", stdout, stderr, 0, file_count=1, dir_count=0)
+
+        assert result.status == scan_status_class.CLEAN
+        assert result.error_message is None
+
+    def test_parse_results_exit_0_unrar_dlopen_warning_is_clean(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """The verified 'Cannot dlopen libclamunrar_iface' warning at exit 0 -> CLEAN."""
+        scanner = daemon_scanner_class()
+
+        stderr = (
+            "LibClamAV Warning: Cannot dlopen libclamunrar_iface: file not found, "
+            "unrar support unavailable\n"
+        )
+
+        result = scanner._parse_results("/home/user", "", stderr, 0, file_count=1, dir_count=0)
+
+        assert result.status == scan_status_class.CLEAN
+        assert result.error_message is None
+        assert result.nonfatal_warnings == [
+            "LibClamAV Warning: Cannot dlopen libclamunrar_iface: file not found, "
+            "unrar support unavailable"
+        ]
+        assert result.has_warnings is True
+
+    def test_parse_results_exit_0_with_per_file_error_reply_is_error(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """Genuine per-file '... ERROR' replies still override exit 0."""
+        scanner = daemon_scanner_class()
+
+        stdout = "/home/user/locked.bin: Can't open file or directory ERROR\n"
+
+        result = scanner._parse_results("/home/user", stdout, "", 0, file_count=1, dir_count=0)
+
+        assert result.status == scan_status_class.ERROR
+        assert result.error_message is not None
+
+    def test_parse_results_total_errors_summary_downgrades_to_clean(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """With -i suppressing per-file lines, 'Total errors: N' downgrades exit 2."""
+        scanner = daemon_scanner_class()
+
+        stdout = """
+----------- SCAN SUMMARY -----------
+Infected files: 0
+Total errors: 2
+Time: 1.000 sec (0 m 1 s)
+"""
+        result = scanner._parse_results("/home/user", stdout, "", 2, file_count=10, dir_count=1)
+
+        assert result.status == scan_status_class.CLEAN
+        assert result.warning_message == "2 file(s) could not be read"
+        assert result.error_message is None
+
+    def test_parse_results_infected_with_nonfatal_warnings_never_masked(
+        self, daemon_scanner_class, scan_status_class
+    ):
+        """Exit 2 with a FOUND line plus benign warnings must stay INFECTED."""
+        scanner = daemon_scanner_class()
+
+        stdout = """
+/home/user/eicar.txt: Eicar-Test-Signature FOUND
+"""
+        stderr = "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN\n"
+
+        result = scanner._parse_results("/home/user", stdout, stderr, 2, file_count=2, dir_count=0)
+
+        assert result.status == scan_status_class.INFECTED
+        assert result.infected_count == 1
+        assert result.nonfatal_warnings == [
+            "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN"
+        ]
+
 
 class TestDaemonScannerProgressParsing:
     """Tests for DaemonScanner._scan_with_progress parsing behavior."""

--- a/tests/core/test_flatpak.py
+++ b/tests/core/test_flatpak.py
@@ -7,6 +7,8 @@ import threading
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from src.core import flatpak
 
 
@@ -1078,27 +1080,70 @@ class TestGetCleanEnv:
             env = flatpak.get_clean_env()
             assert "GI_TYPELIB_PATH" not in env
 
-    def test_strips_full_appimage_python_env(self):
-        """Regression for issue #155: the full AppImage AppRun environment is
-        sanitized of every var that breaks a host Python helper, while
-        host-essential vars survive."""
+    @pytest.mark.parametrize(
+        ("var", "value"),
+        [
+            ("GTK_PATH", "/tmp/mount/usr/lib/gtk-4.0"),
+            ("GTK_EXE_PREFIX", "/tmp/mount/usr"),
+            ("GTK_DATA_PREFIX", "/tmp/mount/usr"),
+            ("GSETTINGS_SCHEMA_DIR", "/tmp/mount/usr/share/glib-2.0/schemas:"),
+            (
+                "GDK_PIXBUF_MODULE_FILE",
+                "/tmp/mount/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+            ),
+            ("GDK_PIXBUF_MODULEDIR", "/tmp/mount/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders"),
+        ],
+    )
+    def test_strips_apprun_gui_vars(self, var, value):
+        """AppRun-exported GTK/GDK/GSettings vars must be stripped so host GTK
+        apps (gufw, firewall-config) don't load the AppImage's bundled GTK
+        modules, schemas, or pixbuf loaders (issue #155 residual)."""
         with mock.patch.dict(
             os.environ,
-            {
-                # AppImage-injected (must be stripped)
-                "PYTHONHOME": "/tmp/mount/usr",
-                "PYTHONPATH": "/tmp/mount/usr/lib/python3.12/site-packages",
-                "PYTHONDONTWRITEBYTECODE": "1",
-                "GI_TYPELIB_PATH": "/tmp/mount/usr/lib/girepository-1.0",
-                "LD_LIBRARY_PATH": "/tmp/mount/usr/lib",
-                "APPDIR": "/tmp/mount",
-                # Host-essential (must survive)
-                "PATH": "/usr/bin:/bin",
-                "HOME": "/home/user",
-                "LANG": "en_US.UTF-8",
-            },
+            {var: value, "HOME": "/home/user"},
             clear=True,
         ):
+            env = flatpak.get_clean_env()
+            assert var not in env
+
+    def test_strips_full_appimage_python_env(self):
+        """Regression for issue #155: the full AppImage AppRun environment is
+        sanitized of every var that breaks a host Python/GTK helper, while
+        host-essential vars survive. Values mirror appimage/build-appimage.sh's
+        AppRun exports plus the APPIMAGE var set by the AppImage runtime."""
+        apprun_env = {
+            # AppImage-injected (must be stripped)
+            "PYTHONHOME": "/tmp/.mount_ClamUI/usr",
+            "PYTHONPATH": (
+                "/tmp/.mount_ClamUI/usr/lib/python3.12/site-packages:"
+                "/tmp/.mount_ClamUI/usr/lib/python3.12"
+            ),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "GI_TYPELIB_PATH": "/tmp/.mount_ClamUI/usr/lib/girepository-1.0",
+            "LD_LIBRARY_PATH": (
+                "/tmp/.mount_ClamUI/usr/lib:/tmp/.mount_ClamUI/usr/lib/x86_64-linux-gnu"
+            ),
+            "GTK_PATH": "/tmp/.mount_ClamUI/usr/lib/gtk-4.0",
+            "GTK_EXE_PREFIX": "/tmp/.mount_ClamUI/usr",
+            "GTK_DATA_PREFIX": "/tmp/.mount_ClamUI/usr",
+            "GSETTINGS_SCHEMA_DIR": "/tmp/.mount_ClamUI/usr/share/glib-2.0/schemas:",
+            "GDK_PIXBUF_MODULE_FILE": (
+                "/tmp/.mount_ClamUI/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+            ),
+            "GDK_PIXBUF_MODULEDIR": "/tmp/.mount_ClamUI/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders",
+            "APPDIR": "/tmp/.mount_ClamUI",
+            "APPIMAGE": "/home/user/Applications/ClamUI.AppImage",
+            # AppRun prepends the bundled share dir but host tools still need
+            # the host entries, so XDG_DATA_DIRS must survive untouched.
+            "XDG_DATA_DIRS": "/tmp/.mount_ClamUI/usr/share:/usr/local/share:/usr/share",
+        }
+        host_env = {
+            # Host-essential (must survive)
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "LANG": "en_US.UTF-8",
+        }
+        with mock.patch.dict(os.environ, {**apprun_env, **host_env}, clear=True):
             env = flatpak.get_clean_env()
             for stripped in (
                 "PYTHONHOME",
@@ -1106,12 +1151,45 @@ class TestGetCleanEnv:
                 "PYTHONDONTWRITEBYTECODE",
                 "GI_TYPELIB_PATH",
                 "LD_LIBRARY_PATH",
+                "GTK_PATH",
+                "GTK_EXE_PREFIX",
+                "GTK_DATA_PREFIX",
+                "GSETTINGS_SCHEMA_DIR",
+                "GDK_PIXBUF_MODULE_FILE",
+                "GDK_PIXBUF_MODULEDIR",
                 "APPDIR",
+                "APPIMAGE",
             ):
                 assert stripped not in env, f"{stripped} should be stripped"
+            assert env["XDG_DATA_DIRS"] == apprun_env["XDG_DATA_DIRS"]
             assert env["PATH"] == "/usr/bin:/bin"
             assert env["HOME"] == "/home/user"
             assert env["LANG"] == "en_US.UTF-8"
+
+
+class TestCleanEnvWiring:
+    """Wiring tests: get_clean_env() consumers must pass it to subprocess."""
+
+    def test_kde_cache_refresh_passes_clean_env(self):
+        """kbuildsycoca6/5 is a host KDE tool; issue #155 residual requires the
+        sanitized env so leaked AppImage vars don't break it."""
+        from src.core import file_manager_integration as fmi
+
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with (
+            mock.patch.object(fmi, "get_clean_env", return_value=clean_env) as mock_clean,
+            mock.patch.object(
+                fmi,
+                "wrap_host_command",
+                side_effect=lambda cmd, force_host=False: cmd,
+            ),
+            mock.patch("subprocess.run") as mock_run,
+        ):
+            fmi._refresh_dolphin_service_menu_cache()
+
+        mock_clean.assert_called_once()
+        assert mock_run.call_args.args[0] == ["kbuildsycoca6", "--noincremental"]
+        assert mock_run.call_args.kwargs["env"] is clean_env
 
 
 class TestGetClamavDatabaseDir:

--- a/tests/core/test_flatpak.py
+++ b/tests/core/test_flatpak.py
@@ -575,6 +575,7 @@ class TestGetXdgUserDir:
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=mock.ANY,
                 )
 
     def test_get_xdg_user_dir_documents(self):
@@ -647,6 +648,7 @@ class TestGetXdgUserDir:
                     capture_output=True,
                     text=True,
                     timeout=5,
+                    env=mock.ANY,
                 )
 
     def test_get_xdg_user_dir_all_valid_types(self):
@@ -1189,6 +1191,23 @@ class TestCleanEnvWiring:
 
         mock_clean.assert_called_once()
         assert mock_run.call_args.args[0] == ["kbuildsycoca6", "--noincremental"]
+        assert mock_run.call_args.kwargs["env"] is clean_env
+
+    def test_get_xdg_user_dir_passes_clean_env(self):
+        """xdg-user-dir is a host helper and must get the sanitized env."""
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with (
+            mock.patch.object(flatpak, "get_clean_env", return_value=clean_env),
+            mock.patch.object(flatpak, "wrap_host_command", side_effect=lambda cmd: cmd),
+            mock.patch(
+                "subprocess.run",
+                return_value=mock.MagicMock(returncode=0, stdout="/home/user/Downloads\n"),
+            ) as mock_run,
+        ):
+            result = flatpak.get_xdg_user_dir("DOWNLOAD")
+
+        assert result == "/home/user/Downloads"
+        assert mock_run.call_args.args[0] == ["xdg-user-dir", "DOWNLOAD"]
         assert mock_run.call_args.kwargs["env"] is clean_env
 
 

--- a/tests/core/test_log_manager.py
+++ b/tests/core/test_log_manager.py
@@ -1069,6 +1069,41 @@ class TestLogManagerDaemonLogs:
         finally:
             os.unlink(temp_log_path)
 
+    def test_read_daemon_logs_tail_passes_clean_env(self, log_manager):
+        """The tail host helper receives the sanitized environment."""
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with (
+            mock.patch.object(log_manager, "get_daemon_log_path", return_value="/var/log/clamd.log"),
+            mock.patch("src.core.log_manager.wrap_host_command", side_effect=lambda cmd: cmd),
+            mock.patch("src.core.log_manager.get_clean_env", return_value=clean_env),
+            mock.patch(
+                "subprocess.run",
+                return_value=mock.MagicMock(returncode=0, stdout="Line 1\n"),
+            ) as mock_run,
+        ):
+            success, content = log_manager.read_daemon_logs(num_lines=5)
+
+        assert success is True
+        assert mock_run.call_args.args[0][0] == "tail"
+        assert mock_run.call_args.kwargs["env"] is clean_env
+
+    def test_read_daemon_logs_journalctl_passes_clean_env(self, log_manager):
+        """The journalctl host helper receives the sanitized environment."""
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with (
+            mock.patch("src.core.log_manager.wrap_host_command", side_effect=lambda cmd: cmd),
+            mock.patch("src.core.log_manager.get_clean_env", return_value=clean_env),
+            mock.patch(
+                "subprocess.run",
+                return_value=mock.MagicMock(returncode=0, stdout="journal line\n"),
+            ) as mock_run,
+        ):
+            success, content = log_manager._read_daemon_logs_journalctl(num_lines=5)
+
+        assert success is True
+        assert mock_run.call_args.args[0][0] == "journalctl"
+        assert mock_run.call_args.kwargs["env"] is clean_env
+
 
 class TestLogType:
     """Tests for the LogType enum."""

--- a/tests/core/test_result_formatters.py
+++ b/tests/core/test_result_formatters.py
@@ -1,7 +1,12 @@
 # ClamUI Result Formatters Tests
 """Unit tests for the result_formatters module functions."""
 
-from src.core.result_formatters import format_results_as_csv, format_results_as_text
+from src.core.result_formatters import (
+    clean_scan_status_message,
+    compose_scan_warning,
+    format_results_as_csv,
+    format_results_as_text,
+)
 from src.core.scanner import ScanResult, ScanStatus, ThreatDetail
 
 
@@ -638,3 +643,62 @@ class TestFormatResultsAsCsv:
         assert len(rows) == 2
         # The newline should be preserved in the parsed value
         assert "\n" in rows[1][0]
+
+
+class TestComposeScanWarning:
+    """Tests for the compose_scan_warning aggregation helper."""
+
+    def test_skipped_count_takes_precedence(self):
+        warning = compose_scan_warning(3, ["some warning"])
+        assert warning == "3 file(s) could not be accessed"
+
+    def test_warning_messages_joined_without_skips(self):
+        warning = compose_scan_warning(0, ["limit warning A", "limit warning B"])
+        assert warning == "limit warning A; limit warning B"
+
+    def test_no_warnings_returns_none(self):
+        assert compose_scan_warning(0, []) is None
+
+
+class TestCleanScanStatusMessage:
+    """Tests for the clean_scan_status_message banner helper."""
+
+    def _create_clean_result(self, skipped_count=0, warning_message=None) -> ScanResult:
+        return ScanResult(
+            status=ScanStatus.CLEAN,
+            path="/home/user/test",
+            stdout="",
+            stderr="",
+            exit_code=0,
+            infected_files=[],
+            scanned_files=10,
+            scanned_dirs=2,
+            infected_count=0,
+            error_message=None,
+            threat_details=[],
+            skipped_count=skipped_count,
+            warning_message=warning_message,
+        )
+
+    def test_plain_message_without_warnings(self):
+        result = self._create_clean_result()
+        assert clean_scan_status_message(result) == "Scan complete - No threats found"
+
+    def test_skipped_files_render_count(self):
+        result = self._create_clean_result(
+            skipped_count=3, warning_message="3 file(s) could not be accessed"
+        )
+        message = clean_scan_status_message(result)
+        assert message == "Scan complete - No threats found (3 file(s) not accessible)"
+
+    def test_nonfatal_warning_never_renders_zero_files(self):
+        """Regression: skipped_count == 0 with a warning must surface the
+        warning message instead of a bare '0 file(s)' phrase."""
+        result = self._create_clean_result(
+            warning_message="LibClamAV Warning: bytecode execution failed"
+        )
+        message = clean_scan_status_message(result)
+        assert "0 file(s)" not in message
+        assert message == (
+            "Scan complete - No threats found (LibClamAV Warning: bytecode execution failed)"
+        )

--- a/tests/core/test_scanner.py
+++ b/tests/core/test_scanner.py
@@ -885,6 +885,142 @@ LibClamAV Warning: cli_realpath: Invalid arguments.
         ]
         assert result.warning_message == "2 file(s) could not be accessed"
 
+    def test_parse_results_nonfatal_plus_unknown_warning_stays_error(self):
+        """A recognized non-fatal warning must not excuse an unrecognized one (veto)."""
+        scanner = Scanner()
+        stderr = (
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits - "
+            "only scanning 105906176 bytes\n"
+            "LibClamAV Warning: something novel happened\n"
+        )
+
+        result = scanner._parse_results("/", "", stderr, 2)
+
+        assert result.status == ScanStatus.ERROR
+        assert result.error_message is not None
+
+    def test_parse_results_exit_code_2_empty_output_is_error(self):
+        """Exit code 2 with no output at all has no positive signal and stays ERROR."""
+        scanner = Scanner()
+
+        result = scanner._parse_results("/home/user", "", "", 2)
+
+        assert result.status == ScanStatus.ERROR
+        assert result.skipped_count == 0
+        assert result.nonfatal_warnings == []
+        assert result.error_message is None
+
+    def test_parse_results_total_errors_summary_downgrades_to_clean(self):
+        """Regression for the -i mode hole: 'clamui scan' and scheduled scans run
+        clamscan with -i, which suppresses per-file 'Access denied' lines, so exit 2
+        arrives with only the summary's 'Total errors: N' as a positive signal.
+        """
+        scanner = Scanner()
+        stdout = """
+----------- SCAN SUMMARY -----------
+Known viruses: 8000000
+Engine version: 1.2.3
+Scanned directories: 12
+Scanned files: 340
+Infected files: 0
+Total errors: 3
+Data scanned: 120.00 MB
+Time: 10.000 sec (0 m 10 s)
+"""
+        result = scanner._parse_results("/home/user", stdout, "", 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.warning_message == "3 file(s) could not be read"
+        assert result.error_message is None
+        assert result.scanned_files == 340
+
+    def test_parse_results_verbose_access_denied_line_is_skipped(self):
+        """In -v mode the plain '<path>: Access denied' line marks a skipped file."""
+        scanner = Scanner()
+        stdout = """/home/user/test.txt: OK
+/root/secret.txt: Access denied
+
+----------- SCAN SUMMARY -----------
+Scanned files: 1
+Infected files: 0
+Total errors: 1
+"""
+        result = scanner._parse_results("/home/user", stdout, "", 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.skipped_files == ["/root/secret.txt"]
+        assert result.warning_message == "1 file(s) could not be accessed"
+
+    def test_parse_results_cant_access_file_warning_is_skipped(self):
+        """'WARNING: <path>: Can't access file' (file deleted mid-scan) is a skip."""
+        scanner = Scanner()
+        stderr = "WARNING: /home/user/tmp/ephemeral.dat: Can't access file\n"
+
+        result = scanner._parse_results("/home/user", "", stderr, 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.skipped_files == ["/home/user/tmp/ephemeral.dat"]
+
+    def test_parse_results_time_limit_reached_is_skipped(self):
+        """Per-file 'Time limit reached ERROR' lines are partial scans, not failures."""
+        scanner = Scanner()
+        stdout = """/home/user/huge.tar: Time limit reached ERROR
+
+----------- SCAN SUMMARY -----------
+Scanned files: 10
+Infected files: 0
+"""
+        result = scanner._parse_results("/home/user", stdout, "", 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.skipped_files == ["/home/user/huge.tar"]
+
+    def test_parse_results_nonfatal_only_downgrade_sets_warning_fields(self):
+        """A nonfatal-only downgrade must surface the warnings to the caller."""
+        scanner = Scanner()
+        stdout = """
+----------- SCAN SUMMARY -----------
+Scanned files: 50000
+Infected files: 0
+"""
+        stderr = (
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits - "
+            "only scanning 105906176 bytes\n"
+        )
+
+        result = scanner._parse_results("/", stdout, stderr, 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.nonfatal_warnings == [
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits - "
+            "only scanning 105906176 bytes"
+        ]
+        assert result.has_warnings is True
+        assert result.warning_message == (
+            "1 non-fatal warning(s) during scan; some files may have been only partially scanned"
+        )
+
+    def test_parse_results_infected_with_warnings_never_masked(self):
+        """Detections stay INFECTED on exit 1 and 2 despite non-fatal warnings."""
+        scanner = Scanner()
+        stdout = """/home/user/virus.txt: Eicar-Test-Signature FOUND
+
+----------- SCAN SUMMARY -----------
+Scanned files: 5
+Infected files: 1
+"""
+        stderr = "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN\n"
+
+        for exit_code in (1, 2):
+            result = scanner._parse_results("/home/user", stdout, stderr, exit_code)
+
+            assert result.status == ScanStatus.INFECTED
+            assert result.infected_count == 1
+            assert "/home/user/virus.txt" in result.infected_files
+            assert result.nonfatal_warnings == [
+                "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN"
+            ]
+
     def test_scan_result_has_warnings_property(self):
         """Test ScanResult.has_warnings property works correctly."""
         # No warnings
@@ -924,6 +1060,26 @@ LibClamAV Warning: cli_realpath: Invalid arguments.
             warning_message="1 file(s) could not be accessed",
         )
         assert result_with_warnings.has_warnings is True
+
+        # Non-fatal warnings alone (no skipped files) also count as warnings
+        result_nonfatal_only = ScanResult(
+            status=ScanStatus.CLEAN,
+            path="/test",
+            stdout="",
+            stderr="",
+            exit_code=2,
+            infected_files=[],
+            scanned_files=10,
+            scanned_dirs=1,
+            infected_count=0,
+            error_message=None,
+            threat_details=[],
+            skipped_files=[],
+            skipped_count=0,
+            warning_message=None,
+            nonfatal_warnings=["LibClamAV Warning: cli_tnef: file truncated, returning CLEAN"],
+        )
+        assert result_nonfatal_only.has_warnings is True
 
 
 class TestScannerThreatDetailsIntegration:

--- a/tests/core/test_scanner.py
+++ b/tests/core/test_scanner.py
@@ -954,15 +954,19 @@ Total errors: 1
     def test_parse_results_cant_access_file_warning_is_skipped(self):
         """'WARNING: <path>: Can't access file' (file deleted mid-scan) is a skip."""
         scanner = Scanner()
+        stdout = """----------- SCAN SUMMARY -----------
+Scanned files: 1
+Infected files: 0
+"""
         stderr = "WARNING: /home/user/tmp/ephemeral.dat: Can't access file\n"
 
-        result = scanner._parse_results("/home/user", "", stderr, 2)
+        result = scanner._parse_results("/home/user", stdout, stderr, 2)
 
         assert result.status == ScanStatus.CLEAN
         assert result.skipped_files == ["/home/user/tmp/ephemeral.dat"]
 
-    def test_parse_results_time_limit_reached_is_skipped(self):
-        """Per-file 'Time limit reached ERROR' lines are partial scans, not failures."""
+    def test_parse_results_time_limit_reached_is_nonfatal(self):
+        """Per-file 'Time limit reached ERROR' lines are partial scans, not skipped files."""
         scanner = Scanner()
         stdout = """/home/user/huge.tar: Time limit reached ERROR
 
@@ -973,7 +977,39 @@ Infected files: 0
         result = scanner._parse_results("/home/user", stdout, "", 2)
 
         assert result.status == ScanStatus.CLEAN
-        assert result.skipped_files == ["/home/user/huge.tar"]
+        assert result.skipped_files == []
+        assert result.nonfatal_warnings == ["/home/user/huge.tar: Time limit reached ERROR"]
+        assert result.warning_message == (
+            "1 non-fatal warning(s) during scan; some files may have been only partially scanned"
+        )
+
+    def test_parse_results_total_errors_with_zero_scanned_is_error(self):
+        """Exit 2 where every file failed ('Scanned files: 0') must not report CLEAN."""
+        scanner = Scanner()
+        stdout = """----------- SCAN SUMMARY -----------
+Scanned directories: 1
+Scanned files: 0
+Infected files: 0
+Total errors: 3
+"""
+        result = scanner._parse_results("/root", stdout, "", 2)
+
+        assert result.status == ScanStatus.ERROR
+        assert result.error_message == "No files could be scanned"
+
+    def test_parse_results_skipped_files_with_zero_scanned_is_error(self):
+        """Exit 2 with only skip warnings and no scanned files is an all-failed ERROR."""
+        scanner = Scanner()
+        stdout = """----------- SCAN SUMMARY -----------
+Scanned files: 0
+Infected files: 0
+"""
+        stderr = "WARNING: /gone: Can't access file\n"
+
+        result = scanner._parse_results("/gone", stdout, stderr, 2)
+
+        assert result.status == ScanStatus.ERROR
+        assert result.error_message == "No files could be scanned"
 
     def test_parse_results_nonfatal_only_downgrade_sets_warning_fields(self):
         """A nonfatal-only downgrade must surface the warnings to the caller."""

--- a/tests/core/test_scanner_base.py
+++ b/tests/core/test_scanner_base.py
@@ -13,6 +13,7 @@ from src.core.scanner_base import (
     communicate_with_cancel_check,
     create_cancelled_result,
     create_error_result,
+    parse_total_errors,
     stream_process_output,
     terminate_process_gracefully,
 )
@@ -621,3 +622,103 @@ class TestCollectClamavWarnings:
         skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
         assert len(hard_errors) == 1
         assert "Can't allocate memory" in hard_errors[0]
+
+    def test_cant_access_file_warning_classified_as_skipped(self):
+        """clamscan lstat() failure (e.g. file deleted mid-scan) is a skipped file."""
+        stderr = "WARNING: /home/user/tmp/ephemeral.dat: Can't access file\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
+        assert skipped == ["/home/user/tmp/ephemeral.dat"]
+        assert nonfatal == []
+        assert hard_errors == []
+
+    def test_cant_open_file_warning_classified_as_skipped(self):
+        """clamscan open() failure names the path AFTER the marker."""
+        stderr = "WARNING: Can't open file /home/user/locked.bin: Permission denied\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
+        assert skipped == ["/home/user/locked.bin"]
+        assert nonfatal == []
+        assert hard_errors == []
+
+    def test_unrar_dlopen_warning_is_nonfatal(self):
+        """Missing optional unrar module is informational, not an error."""
+        stderr = (
+            "LibClamAV Warning: Cannot dlopen libclamunrar_iface: file not found, "
+            "unrar support unavailable\n"
+        )
+        skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
+        assert skipped == []
+        assert len(nonfatal) == 1
+        assert "libclamunrar_iface" in nonfatal[0]
+        assert hard_errors == []
+
+    def test_bytecode_timeout_warning_is_nonfatal(self):
+        """Bytecode signature timeouts are by-design protections, not errors."""
+        stderr = "LibClamAV Warning: Bytecode run timed out, timeout flag set\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
+        assert skipped == []
+        assert len(nonfatal) == 1
+        assert hard_errors == []
+
+    def test_per_file_time_limit_reached_classified_as_skipped(self):
+        """Per-file CL_ETIMEOUT lines end with ERROR but are partial scans, not failures."""
+        stdout = "/home/user/huge.tar: Time limit reached ERROR\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == ["/home/user/huge.tar"]
+        assert hard_errors == []
+
+    def test_per_file_access_denied_classified_as_skipped(self):
+        """Plain 'Access denied' lines from clamscan -v are skipped files."""
+        stdout = "/root/secret.txt: Access denied\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == ["/root/secret.txt"]
+        assert hard_errors == []
+
+    def test_clamdscan_access_denied_error_line_classified_as_skipped(self):
+        """clamdscan's 'Access denied. ERROR' replies are skipped files."""
+        stdout = "/root/secret.txt: Access denied. ERROR\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == ["/root/secret.txt"]
+        assert hard_errors == []
+
+    def test_unknown_libclamav_warning_stays_hard_error(self):
+        """Unrecognized LibClamAV warnings must keep vetoing the benign downgrade."""
+        stderr = "LibClamAV Warning: something novel happened\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings("", stderr)
+        assert skipped == []
+        assert nonfatal == []
+        assert hard_errors == ["LibClamAV Warning: something novel happened"]
+
+    def test_unknown_per_file_error_line_stays_hard_error(self):
+        """Unknown per-file '... ERROR' replies must stay hard errors."""
+        stdout = "/home/user/file.bin: SomeThing ERROR\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == []
+        assert hard_errors == ["/home/user/file.bin: SomeThing ERROR"]
+
+    def test_file_list_cant_open_error_stays_hard_error(self):
+        """clamdscan's own 'ERROR: ... Can't open file' must not be swallowed."""
+        stdout = "ERROR: --file-list: Can't open file /run/user/1000/clamui_filelist.txt\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == []
+        assert len(hard_errors) == 1
+
+
+class TestParseTotalErrors:
+    """Tests for parse_total_errors summary parsing."""
+
+    def test_parses_total_errors_from_summary(self):
+        stdout = (
+            "----------- SCAN SUMMARY -----------\n"
+            "Scanned files: 340\n"
+            "Infected files: 0\n"
+            "Total errors: 3\n"
+            "Time: 10.000 sec (0 m 10 s)\n"
+        )
+        assert parse_total_errors(stdout) == 3
+
+    def test_returns_zero_when_summary_line_absent(self):
+        stdout = "----------- SCAN SUMMARY -----------\nScanned files: 5\n"
+        assert parse_total_errors(stdout) == 0
+
+    def test_returns_zero_for_empty_output(self):
+        assert parse_total_errors("") == 0

--- a/tests/core/test_scanner_base.py
+++ b/tests/core/test_scanner_base.py
@@ -8,6 +8,7 @@ from src.core.scanner_base import (
     KILL_WAIT_TIMEOUT,
     STREAM_POLL_TIMEOUT,
     TERMINATE_GRACE_TIMEOUT,
+    _extract_skipped_path,
     cleanup_process,
     collect_clamav_warnings,
     communicate_with_cancel_check,
@@ -659,12 +660,33 @@ class TestCollectClamavWarnings:
         assert len(nonfatal) == 1
         assert hard_errors == []
 
-    def test_per_file_time_limit_reached_classified_as_skipped(self):
-        """Per-file CL_ETIMEOUT lines end with ERROR but are partial scans, not failures."""
+    def test_per_file_time_limit_reached_classified_as_nonfatal(self):
+        """Per-file CL_ETIMEOUT lines are partial scans: nonfatal, not skipped files."""
         stdout = "/home/user/huge.tar: Time limit reached ERROR\n"
         skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
-        assert skipped == ["/home/user/huge.tar"]
+        assert skipped == []
+        assert nonfatal == ["/home/user/huge.tar: Time limit reached ERROR"]
         assert hard_errors == []
+
+    def test_marker_first_cant_access_file_extracts_trailing_path(self):
+        """clamdscan's 'ERROR: Can't access file <path>' names the path AFTER the marker."""
+        assert _extract_skipped_path("ERROR: Can't access file /root/gone.bin") == "/root/gone.bin"
+
+    def test_marker_first_cant_access_file_lines_yield_distinct_paths(self):
+        """Two marker-first access errors must produce two distinct skipped paths."""
+        stdout = (
+            "ERROR: Can't access file /root/gone.bin\nERROR: Can't access file /root/gone2.bin\n"
+        )
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == ["/root/gone.bin", "/root/gone2.bin"]
+        assert hard_errors == []
+
+    def test_novel_marker_first_line_does_not_yield_garbage_path(self):
+        """Unknown marker-first wordings must stay hard errors, not become path 'ERROR'."""
+        stdout = "ERROR: Access denied\n"
+        skipped, nonfatal, hard_errors = collect_clamav_warnings(stdout, "")
+        assert skipped == []
+        assert hard_errors == ["ERROR: Access denied"]
 
     def test_per_file_access_denied_classified_as_skipped(self):
         """Plain 'Access denied' lines from clamscan -v are skipped files."""
@@ -707,6 +729,7 @@ class TestParseTotalErrors:
     """Tests for parse_total_errors summary parsing."""
 
     def test_parses_total_errors_from_summary(self):
+        """The 'Total errors: N' summary line yields its numeric count."""
         stdout = (
             "----------- SCAN SUMMARY -----------\n"
             "Scanned files: 340\n"
@@ -717,8 +740,10 @@ class TestParseTotalErrors:
         assert parse_total_errors(stdout) == 3
 
     def test_returns_zero_when_summary_line_absent(self):
+        """A summary without a 'Total errors' line parses as zero errors."""
         stdout = "----------- SCAN SUMMARY -----------\nScanned files: 5\n"
         assert parse_total_errors(stdout) == 0
 
     def test_returns_zero_for_empty_output(self):
+        """Empty scanner output parses as zero errors."""
         assert parse_total_errors("") == 0

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1219,18 +1219,6 @@ class TestSchedulerCliCommandTokenization:
         assert words[0] == cli
         assert words[1:] == ["--target", "/home/user name/Documents"]
 
-    def test_systemd_bare_string_cli_treated_as_single_token(self, scheduler):
-        """Back-compat: a bare string cli_command is one path, never word-split."""
-        cli = "/home/user name/.local/share/clamui/venv/bin/clamui-scheduled-scan"
-        service = scheduler._generate_service_file(
-            cli_command=cli,
-            targets=["/tmp/x"],
-            skip_on_battery=False,
-            auto_quarantine=False,
-        )
-
-        assert self._exec_start_words(service)[0] == cli
-
     def test_systemd_cli_path_with_quote_roundtrips(self, scheduler):
         """A path containing a single quote must not raise 'No closing quotation'."""
         cli = "/home/user's files/venv/bin/clamui-scheduled-scan"

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -2,6 +2,7 @@
 """Unit tests for the Scheduler class."""
 
 import os
+import shlex
 import sys
 import tempfile
 from pathlib import Path
@@ -377,7 +378,7 @@ class TestSchedulerServiceFiles:
     def test_generate_service_file(self, scheduler):
         """Test service file generation."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/Documents"],
             skip_on_battery=True,
             auto_quarantine=False,
@@ -396,7 +397,7 @@ class TestSchedulerServiceFiles:
     def test_generate_service_file_with_quarantine(self, scheduler):
         """Test service file generation with quarantine enabled."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/Downloads"],
             skip_on_battery=False,
             auto_quarantine=True,
@@ -408,7 +409,7 @@ class TestSchedulerServiceFiles:
     def test_generate_service_file_multiple_targets(self, scheduler):
         """Test service file generation with multiple targets."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/Documents", "/home/user/Downloads"],
             skip_on_battery=True,
             auto_quarantine=True,
@@ -432,7 +433,7 @@ class TestSchedulerServiceFiles:
     def test_generate_service_file_special_chars_quoted(self, scheduler):
         """Test service file properly quotes paths with special characters."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/My Documents", "/path/with'quotes"],
             skip_on_battery=True,
             auto_quarantine=False,
@@ -580,7 +581,7 @@ class TestSchedulerSystemdIntegration:
             mock.patch.object(
                 scheduler,
                 "_get_cli_command_path",
-                return_value="/usr/bin/clamui-scheduled-scan",
+                return_value=["/usr/bin/clamui-scheduled-scan"],
             ),
             mock.patch("subprocess.run") as mock_run,
         ):
@@ -884,7 +885,7 @@ class TestGetCliCommandPath:
 
                 result = scheduler._get_cli_command_path()
 
-                assert result == "/usr/bin/clamui-scheduled-scan"
+                assert result == ["/usr/bin/clamui-scheduled-scan"]
                 mock_which.assert_called_with("clamui-scheduled-scan")
 
     def test_returns_venv_path_when_exists(self, scheduler):
@@ -906,7 +907,7 @@ class TestGetCliCommandPath:
                     with mock.patch("src.core.scheduler.is_flatpak", return_value=False):
                         result = scheduler._get_cli_command_path()
 
-                        assert result == str(cli_script)
+                        assert result == [str(cli_script)]
 
     def test_returns_module_execution_with_venv_python(self, scheduler):
         """Test falls back to module execution when only venv Python exists."""
@@ -927,8 +928,7 @@ class TestGetCliCommandPath:
                     with mock.patch("src.core.scheduler.is_flatpak", return_value=False):
                         result = scheduler._get_cli_command_path()
 
-                        assert str(python_bin) in result
-                        assert "-m src.cli.scheduled_scan" in result
+                        assert result == [str(python_bin), "-m", "src.cli.scheduled_scan"]
 
     def test_correct_module_path_in_fallback(self, scheduler):
         """Test that fallback uses correct module path src.cli.scheduled_scan."""
@@ -942,12 +942,10 @@ class TestGetCliCommandPath:
                     with mock.patch.object(scheduler, "_check_path_exists", return_value=False):
                         result = scheduler._get_cli_command_path()
 
-                        # Should use correct module path
+                        # Should use correct module path (exact token)
                         assert "src.cli.scheduled_scan" in result
                         # Should NOT use the old buggy path
-                        assert (
-                            "src.scheduled_scan" not in result or "src.cli.scheduled_scan" in result
-                        )
+                        assert "src.scheduled_scan" not in result
 
     def test_prefers_entry_point_over_module(self, scheduler):
         """Test that entry point script is preferred over module execution."""
@@ -972,7 +970,7 @@ class TestGetCliCommandPath:
                         result = scheduler._get_cli_command_path()
 
                     # Should return entry point, not module execution
-                    assert result == str(cli_script)
+                    assert result == [str(cli_script)]
                     assert "-m" not in result
 
     def test_returns_none_when_nothing_found(self, scheduler):
@@ -990,11 +988,13 @@ class TestGetCliCommandPath:
             with mock.patch.dict("os.environ", {"FLATPAK_ID": "io.github.linx_systems.ClamUI"}):
                 result = scheduler._get_cli_command_path()
 
-                # Should return flatpak run command with --command= syntax
-                assert (
-                    result
-                    == "flatpak run --command=clamui-scheduled-scan io.github.linx_systems.ClamUI"
-                )
+                # Should return flatpak run command tokens with --command= syntax
+                assert result == [
+                    "flatpak",
+                    "run",
+                    "--command=clamui-scheduled-scan",
+                    "io.github.linx_systems.ClamUI",
+                ]
 
     def test_flatpak_uses_default_app_id_if_not_in_env(self, scheduler):
         """Test that Flatpak mode uses default app ID if FLATPAK_ID not set."""
@@ -1005,10 +1005,12 @@ class TestGetCliCommandPath:
                 result = scheduler._get_cli_command_path()
 
                 # Should use default app ID with --command= syntax
-                assert (
-                    result
-                    == "flatpak run --command=clamui-scheduled-scan io.github.linx_systems.ClamUI"
-                )
+                assert result == [
+                    "flatpak",
+                    "run",
+                    "--command=clamui-scheduled-scan",
+                    "io.github.linx_systems.ClamUI",
+                ]
 
 
 class TestSchedulerMultiTokenAndPercentEscaping:
@@ -1059,10 +1061,10 @@ class TestSchedulerMultiTokenAndPercentEscaping:
         return captured["new_crontab"].splitlines()[-1]
 
     def test_systemd_multitoken_cli_emitted_as_separate_args(self, scheduler):
-        """Multi-token cli_path must not be wrapped as one quoted ExecStart blob."""
-        cli_path = "flatpak run --command=clamui-scheduled-scan org.x.App"
+        """Multi-token cli command must not be wrapped as one quoted ExecStart blob."""
+        cli_command = ["flatpak", "run", "--command=clamui-scheduled-scan", "org.x.App"]
         service = scheduler._generate_service_file(
-            cli_path=cli_path,
+            cli_command=cli_command,
             targets=["/home/user/Documents"],
             skip_on_battery=False,
             auto_quarantine=False,
@@ -1071,21 +1073,21 @@ class TestSchedulerMultiTokenAndPercentEscaping:
         # Tokens appear as separate args, executable as-is.
         assert "ExecStart=flatpak run --command=clamui-scheduled-scan org.x.App" in service
         # The buggy single-token quoting would emit the whole command quoted.
-        assert f"'{cli_path}'" not in service
+        assert f"'{' '.join(cli_command)}'" not in service
 
     def test_cron_multitoken_cli_emitted_as_separate_args(self, scheduler):
-        """Multi-token cli_path must not be wrapped as one quoted cron command blob."""
-        cli_path = "flatpak run --command=clamui-scheduled-scan org.x.App"
-        with mock.patch.object(scheduler, "_get_cli_command_path", return_value=cli_path):
+        """Multi-token cli command must not be wrapped as one quoted cron command blob."""
+        cli_command = ["flatpak", "run", "--command=clamui-scheduled-scan", "org.x.App"]
+        with mock.patch.object(scheduler, "_get_cli_command_path", return_value=cli_command):
             cron_line = self._capture_cron_entry(scheduler, ["/home/user/Documents"])
 
         assert "flatpak run --command=clamui-scheduled-scan org.x.App" in cron_line
-        assert f"'{cli_path}'" not in cron_line
+        assert f"'{' '.join(cli_command)}'" not in cron_line
 
     def test_systemd_escapes_literal_percent_in_target(self, scheduler):
         """A '%' in a target path must be doubled to '%%' for systemd specifiers."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/50%off"],
             skip_on_battery=False,
             auto_quarantine=False,
@@ -1098,7 +1100,7 @@ class TestSchedulerMultiTokenAndPercentEscaping:
     def test_cron_escapes_literal_percent_in_target(self, scheduler):
         """A '%' in a target path must be backslash-escaped for cron."""
         with mock.patch.object(
-            scheduler, "_get_cli_command_path", return_value="/usr/bin/clamui-scheduled-scan"
+            scheduler, "_get_cli_command_path", return_value=["/usr/bin/clamui-scheduled-scan"]
         ):
             cron_line = self._capture_cron_entry(scheduler, ["/home/user/50%off"])
 
@@ -1114,7 +1116,7 @@ class TestSchedulerMultiTokenAndPercentEscaping:
         time.  The documented literal-dollar escape is '$$'.
         """
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["/home/user/${HOME}/x"],
             skip_on_battery=False,
             auto_quarantine=False,
@@ -1129,7 +1131,7 @@ class TestSchedulerMultiTokenAndPercentEscaping:
     def test_systemd_escapes_standalone_dollar_var_target(self, scheduler):
         """A target that is exactly '$VAR' must also be neutralized."""
         service = scheduler._generate_service_file(
-            cli_path="/usr/bin/clamui-scheduled-scan",
+            cli_command=["/usr/bin/clamui-scheduled-scan"],
             targets=["$HOME"],
             skip_on_battery=False,
             auto_quarantine=False,
@@ -1146,9 +1148,252 @@ class TestSchedulerMultiTokenAndPercentEscaping:
         or the literal '$$' would reach the shell verbatim.
         """
         with mock.patch.object(
-            scheduler, "_get_cli_command_path", return_value="/usr/bin/clamui-scheduled-scan"
+            scheduler, "_get_cli_command_path", return_value=["/usr/bin/clamui-scheduled-scan"]
         ):
             cron_line = self._capture_cron_entry(scheduler, ["/home/user/${HOME}/x"])
 
         assert "/home/user/${HOME}/x" in cron_line
         assert "$$" not in cron_line
+
+
+class TestSchedulerCliCommandTokenization:
+    """Regression tests for issue #150 residuals — flat-string command re-splitting.
+
+    _get_cli_command_path() now returns argv tokens (list[str]); consumers must
+    quote each token verbatim and never shlex.split() a flat command string.
+    Previously a single executable path containing a space was re-split into
+    two tokens (ExecStart exec'd '/home/user' -> silent 203/EXEC) and a path
+    containing a quote raised shlex "No closing quotation".
+    """
+
+    @pytest.fixture
+    def scheduler(self):
+        """Create a Scheduler instance."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Scheduler(config_dir=Path(tmpdir))
+
+    @staticmethod
+    def _exec_start_words(service):
+        """Shell-parse the ExecStart line of a service file into words."""
+        exec_line = next(line for line in service.splitlines() if line.startswith("ExecStart="))
+        return shlex.split(exec_line[len("ExecStart=") :])
+
+    def _capture_cron_command(self, scheduler, cli_command, targets):
+        """Run _enable_cron_schedule with mocked crontab subprocess calls.
+
+        Returns the shell command portion (after the five time fields) of the
+        cron entry that would have been written.
+        """
+        captured = {"new_crontab": None}
+
+        def fake_run(cmd, *args, **kwargs):
+            # First call is `crontab -l`, second is `crontab -` (write).
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if "-l" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="", stderr="")
+            captured["new_crontab"] = kwargs.get("input", "")
+            return mock.MagicMock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(scheduler, "_get_cli_command_path", return_value=cli_command):
+            with mock.patch("src.core.scheduler.subprocess.run", side_effect=fake_run):
+                success, err = scheduler._enable_cron_schedule(
+                    ScheduleFrequency.DAILY, "02:00", targets, 0, 1, False, False
+                )
+
+        assert success is True, err
+        cron_line = captured["new_crontab"].splitlines()[-1]
+        return cron_line.split(" ", 5)[5]
+
+    def test_systemd_cli_path_with_space_roundtrips(self, scheduler):
+        """A venv path containing a space must stay one argv[0] word (issue #150)."""
+        cli = "/home/user name/.local/share/clamui/venv/bin/clamui-scheduled-scan"
+        service = scheduler._generate_service_file(
+            cli_command=[cli],
+            targets=["/home/user name/Documents"],
+            skip_on_battery=False,
+            auto_quarantine=False,
+        )
+
+        words = self._exec_start_words(service)
+        # First shell-parsed word is the full path, not '/home/user'.
+        assert words[0] == cli
+        assert words[1:] == ["--target", "/home/user name/Documents"]
+
+    def test_systemd_bare_string_cli_treated_as_single_token(self, scheduler):
+        """Back-compat: a bare string cli_command is one path, never word-split."""
+        cli = "/home/user name/.local/share/clamui/venv/bin/clamui-scheduled-scan"
+        service = scheduler._generate_service_file(
+            cli_command=cli,
+            targets=["/tmp/x"],
+            skip_on_battery=False,
+            auto_quarantine=False,
+        )
+
+        assert self._exec_start_words(service)[0] == cli
+
+    def test_systemd_cli_path_with_quote_roundtrips(self, scheduler):
+        """A path containing a single quote must not raise 'No closing quotation'."""
+        cli = "/home/user's files/venv/bin/clamui-scheduled-scan"
+        service = scheduler._generate_service_file(
+            cli_command=[cli],
+            targets=["/home/user/Documents"],
+            skip_on_battery=False,
+            auto_quarantine=False,
+        )
+
+        assert self._exec_start_words(service)[0] == cli
+
+    def test_enable_systemd_with_quote_in_cli_path_succeeds(self, scheduler):
+        """Enabling must not surface 'Error enabling schedule: No closing quotation'."""
+        cli = "/home/user's files/venv/bin/clamui-scheduled-scan"
+        with (
+            mock.patch.object(scheduler, "_get_cli_command_path", return_value=[cli]),
+            mock.patch("src.core.scheduler.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout="", stderr="")
+            success, error = scheduler._enable_systemd_schedule(
+                ScheduleFrequency.DAILY, "02:00", ["/home/user/Documents"], 0, 1, False, False
+            )
+
+        assert success is True
+        assert error is None
+        service = (scheduler._systemd_dir / f"{scheduler.SERVICE_NAME}.service").read_text()
+        assert self._exec_start_words(service)[0] == cli
+
+    def test_systemd_dollar_in_executable_not_doubled_but_target_is(self, scheduler):
+        """'$'->'$$' escaping applies to arguments only, never argv[0].
+
+        systemd does not variable-expand the executable word, so doubling a
+        literal '$' there would corrupt the path to '$$'.  Targets must still
+        be escaped since systemd expands '${VAR}' in arguments.
+        """
+        cli = "/opt/apps/$pecial/bin/clamui-scheduled-scan"
+        service = scheduler._generate_service_file(
+            cli_command=[cli],
+            targets=["/data/${HOME}/x"],
+            skip_on_battery=False,
+            auto_quarantine=False,
+        )
+
+        exec_line = next(line for line in service.splitlines() if line.startswith("ExecStart="))
+        # Executable keeps its single '$'...
+        assert "$$pecial" not in exec_line
+        assert self._exec_start_words(service)[0] == cli
+        # ...while the target's '$' is still doubled.
+        assert "/data/$${HOME}/x" in exec_line
+
+    def test_cron_cli_path_with_space_roundtrips(self, scheduler):
+        """A venv path containing a space must stay one command word in cron."""
+        cli = "/home/user name/.local/share/clamui/venv/bin/clamui-scheduled-scan"
+        cron_cmd = self._capture_cron_command(scheduler, [cli], ["/home/user name/Documents"])
+
+        words = shlex.split(cron_cmd)
+        assert words[0] == cli
+        assert words[1:] == ["--target", "/home/user name/Documents"]
+
+    def test_cron_cli_path_with_quote_roundtrips(self, scheduler):
+        """A path containing a single quote must not error in the cron path."""
+        cli = "/home/user's files/venv/bin/clamui-scheduled-scan"
+        cron_cmd = self._capture_cron_command(scheduler, [cli], ["/home/user/Documents"])
+
+        assert shlex.split(cron_cmd)[0] == cli
+
+    def test_cron_dollar_in_executable_stays_single(self, scheduler):
+        """The systemd '$$' escape must never touch the cron executable word."""
+        cli = "/opt/apps/$pecial/bin/clamui-scheduled-scan"
+        cron_cmd = self._capture_cron_command(scheduler, [cli], ["/home/user/Documents"])
+
+        assert "$$" not in cron_cmd
+        assert shlex.split(cron_cmd)[0] == cli
+
+    def test_flatpak_tokens_render_issue_150_execstart(self, scheduler):
+        """The Flatpak token list must render the exact working ExecStart (issue #150)."""
+        with mock.patch("src.core.scheduler.is_flatpak", return_value=True):
+            with mock.patch.dict("os.environ", {"FLATPAK_ID": "io.github.linx_systems.ClamUI"}):
+                tokens = scheduler._get_cli_command_path()
+
+        service = scheduler._generate_service_file(
+            cli_command=tokens,
+            targets=["/home/user/Documents"],
+            skip_on_battery=True,
+            auto_quarantine=False,
+        )
+
+        assert (
+            "ExecStart=flatpak run --command=clamui-scheduled-scan "
+            "io.github.linx_systems.ClamUI --skip-on-battery "
+            "--target /home/user/Documents" in service
+        )
+
+
+class TestSchedulerCleanEnv:
+    """systemctl/crontab subprocess calls must run with get_clean_env().
+
+    AppImage runtime variables (LD_LIBRARY_PATH, PYTHONHOME, ...) must not
+    leak into host helpers, matching the convention of sibling core modules
+    (see GitHub issue #155 and src.core.flatpak.get_clean_env).
+    """
+
+    @pytest.fixture
+    def scheduler(self):
+        """Create a Scheduler instance."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Scheduler(config_dir=Path(tmpdir))
+
+    def test_systemd_enable_uses_clean_env(self, scheduler):
+        """daemon-reload and enable --now must pass env=get_clean_env()."""
+        with (
+            mock.patch.object(
+                scheduler,
+                "_get_cli_command_path",
+                return_value=["/usr/bin/clamui-scheduled-scan"],
+            ),
+            mock.patch("src.core.scheduler.get_clean_env", return_value={"CLEAN": "1"}),
+            mock.patch("src.core.scheduler.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout="", stderr="")
+            success, _err = scheduler._enable_systemd_schedule(
+                ScheduleFrequency.DAILY, "02:00", ["/tmp/x"], 0, 1, False, False
+            )
+
+        assert success is True
+        assert len(mock_run.call_args_list) == 2  # daemon-reload, enable --now
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("env") == {"CLEAN": "1"}
+
+    def test_cron_enable_uses_clean_env(self, scheduler):
+        """crontab -l and crontab - must pass env=get_clean_env()."""
+        with (
+            mock.patch.object(
+                scheduler,
+                "_get_cli_command_path",
+                return_value=["/usr/bin/clamui-scheduled-scan"],
+            ),
+            mock.patch("src.core.scheduler.get_clean_env", return_value={"CLEAN": "1"}),
+            mock.patch("src.core.scheduler.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout="", stderr="")
+            success, _err = scheduler._enable_cron_schedule(
+                ScheduleFrequency.DAILY, "02:00", ["/tmp/x"], 0, 1, False, False
+            )
+
+        assert success is True
+        assert len(mock_run.call_args_list) == 2  # crontab -l, crontab -
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("env") == {"CLEAN": "1"}
+
+    def test_cron_disable_uses_clean_env(self, scheduler):
+        """crontab -l and the rewrite/removal must pass env=get_clean_env()."""
+        marker = scheduler.CRON_MARKER
+        crontab = f"{marker}\n0 2 * * * /usr/bin/clamui-scheduled-scan --target /home\n"
+        with (
+            mock.patch("src.core.scheduler.get_clean_env", return_value={"CLEAN": "1"}),
+            mock.patch("src.core.scheduler.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0, stdout=crontab, stderr="")
+            success, _err = scheduler._disable_cron_schedule()
+
+        assert success is True
+        assert len(mock_run.call_args_list) == 2  # crontab -l, crontab -r (empty)
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("env") == {"CLEAN": "1"}

--- a/tests/core/test_system_audit.py
+++ b/tests/core/test_system_audit.py
@@ -4,6 +4,7 @@
 import subprocess
 from unittest.mock import MagicMock, patch
 
+from src.core.flatpak import get_clean_env
 from src.core.portmaster_client import (
     PortmasterModuleRow,
     PortmasterProbeResult,
@@ -23,6 +24,7 @@ from src.core.system_audit import (
     _get_database_age,
     _parse_cvd_age,
     _parse_sshd_config,
+    _run_command,
     check_auto_updates,
     check_clamav_health,
     check_firewall,
@@ -256,6 +258,63 @@ class TestParseCvdAge:
         days_old, date_str = _parse_cvd_age(str(cvd_file))
         assert days_old == 3
         assert date_str == "24 Jun 2026"
+
+    @patch("src.core.system_audit.subprocess.run")
+    @patch("src.core.system_audit.is_flatpak", return_value=True)
+    def test_flatpak_head_bytes_stdout_with_gzip_payload(self, mock_is_flatpak, mock_run):
+        """Regression for issue #162 (reported on Flatpak): the header is read
+        via ``flatpak-spawn --host head -c 512`` WITHOUT text=True, so stdout
+        is raw BYTES with the gzip payload glued straight onto the stime
+        digits. The bytes path must decode and parse just like direct file I/O.
+        """
+        import time
+
+        build_ts = int(time.time()) - (3 * 86400)
+        header_text = f"ClamAV-VDB:24 Jun 2026:27000:2000000:90:md5:dsig:builder:{build_ts}"
+        # gzip magic then a spread of high and low bytes, appended directly
+        # after the stime digits with no separator; exactly 512 bytes total,
+        # as `head -c 512` returns on a real daily.cld.
+        junk = b"\x1f\x8b\x08\x00" + bytes(range(255, -1, -1)) * 2
+        raw = (header_text.encode("ascii") + junk)[:512]
+        assert len(raw) == 512
+        mock_run.return_value = MagicMock(returncode=0, stdout=raw, stderr=b"")
+
+        days_old, date_str = _parse_cvd_age("/var/lib/clamav/daily.cld")
+
+        assert days_old == 3
+        assert date_str == "24 Jun 2026"
+        mock_is_flatpak.assert_called_once()
+
+    def test_stime_with_no_leading_digits(self, tmp_path):
+        """When the 9th field starts directly with non-digit binary bytes
+        (payload where the stime should be), the digit-run match returns None
+        and the ValueError path must report the timestamp parse error."""
+        header_text = "ClamAV-VDB:24 Jun 2026:27000:2000000:90:md5:dsig:builder:"
+        junk = b"\x1f\x8b\x08\x00\x1e-3<>i\x7f$2Yi\x01*X\x01wvi"
+        cvd_file = tmp_path / "daily.cld"
+        cvd_file.write_bytes(header_text.encode("ascii") + junk)
+
+        days_old, error = _parse_cvd_age(str(cvd_file))
+        assert days_old is None
+        assert error == "Could not parse database timestamp"
+
+
+class TestRunCommand:
+    """Tests for the _run_command helper."""
+
+    @patch.dict("os.environ", {"LD_PRELOAD": "/appimage/bundled/libbogus.so"})
+    @patch("src.core.system_audit.subprocess.run")
+    def test_passes_clean_env_to_subprocess(self, mock_run):
+        """_run_command must pass env=get_clean_env() so AppImage runtime vars
+        never leak into host helpers (issue #155); a refactor dropping the env
+        kwarg would otherwise regress silently."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="active\n", stderr="")
+
+        _run_command(["systemctl", "is-active", "clamav-daemon"])
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env == get_clean_env()
+        assert "LD_PRELOAD" not in env
 
 
 class TestDatabaseAgeDaemonFallback:

--- a/tests/core/test_updater.py
+++ b/tests/core/test_updater.py
@@ -2708,6 +2708,40 @@ class TestProbeSubprocessCleanEnv:
         assert pid == "777"
         assert mock_run.call_args.kwargs["env"] is clean_env
 
+    def test_trigger_service_update_kill_passes_clean_env(self, updater_module):
+        """Both the kill and pkexec-kill signal commands get the clean env."""
+        from src.core.updater import FreshclamServiceStatus, FreshclamUpdater
+
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        env_by_cmd = {}
+
+        def mock_run(cmd, *args, **kwargs):
+            env_by_cmd[cmd[0]] = kwargs.get("env")
+            if cmd[0] == "kill":
+                # Regular kill fails so the pkexec fallback runs too
+                return MagicMock(returncode=1, stderr="Operation not permitted")
+            if cmd[0] == "/usr/bin/pkexec":
+                return MagicMock(returncode=0, stderr="")
+            return MagicMock(returncode=1, stdout="")
+
+        updater = FreshclamUpdater(log_manager=MagicMock())
+        with (
+            patch.object(
+                updater,
+                "check_freshclam_service",
+                return_value=(FreshclamServiceStatus.RUNNING, "123"),
+            ),
+            patch("src.core.updater.get_pkexec_path", return_value="/usr/bin/pkexec"),
+            patch("src.core.updater.get_clean_env", return_value=clean_env),
+            patch("src.core.updater.wrap_host_command", side_effect=lambda x: x),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            success, _message = updater.trigger_service_update()
+
+        assert success is True
+        assert env_by_cmd["kill"] is clean_env
+        assert env_by_cmd["/usr/bin/pkexec"] is clean_env
+
 
 # =============================================================================
 # Additional UpdateResult Tests

--- a/tests/core/test_updater.py
+++ b/tests/core/test_updater.py
@@ -2620,6 +2620,96 @@ class TestTriggerServiceUpdateAdditional:
 
 
 # =============================================================================
+# Clean-Env Wiring Tests (issue #155 residuals)
+# =============================================================================
+
+
+class TestProbeSubprocessCleanEnv:
+    """Host-state probes (systemctl is-active, pidof) must receive the
+    sanitized environment so leaked AppImage vars don't break them."""
+
+    def test_check_freshclam_service_passes_clean_env(self, updater_module):
+        """systemctl is-active and pidof both receive env=get_clean_env()."""
+        from src.core.updater import FreshclamServiceStatus, FreshclamUpdater
+
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        env_by_cmd = {}
+
+        def mock_run(cmd, *args, **kwargs):
+            env_by_cmd[cmd[0]] = kwargs.get("env")
+            if "is-active" in cmd:
+                return MagicMock(returncode=0, stdout="active")
+            if "pidof" in cmd:
+                return MagicMock(returncode=0, stdout="12345")
+            return MagicMock(returncode=1, stdout="")
+
+        with (
+            patch("src.core.updater.get_clean_env", return_value=clean_env),
+            patch("src.core.updater.wrap_host_command", side_effect=lambda x: x),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            updater = FreshclamUpdater(log_manager=MagicMock())
+            status, pid = updater.check_freshclam_service()
+
+        assert status == FreshclamServiceStatus.RUNNING
+        assert pid == "12345"
+        assert env_by_cmd["systemctl"] is clean_env
+        assert env_by_cmd["pidof"] is clean_env
+
+    def test_trigger_service_update_pid_probe_passes_clean_env(self, updater_module):
+        """The pidof retry inside trigger_service_update() gets the clean env."""
+        from src.core.updater import FreshclamServiceStatus, FreshclamUpdater
+
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        env_by_cmd = {}
+
+        def mock_run(cmd, *args, **kwargs):
+            env_by_cmd[cmd[0]] = kwargs.get("env")
+            if "pidof" in cmd:
+                return MagicMock(returncode=0, stdout="54321")
+            if "kill" in cmd:
+                return MagicMock(returncode=0, stderr="")
+            return MagicMock(returncode=1, stdout="")
+
+        updater = FreshclamUpdater(log_manager=MagicMock())
+        with (
+            patch.object(
+                updater,
+                "check_freshclam_service",
+                return_value=(FreshclamServiceStatus.RUNNING, None),
+            ),
+            patch("src.core.updater.get_clean_env", return_value=clean_env),
+            patch("src.core.updater.wrap_host_command", side_effect=lambda x: x),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            success, _message = updater.trigger_service_update()
+
+        assert success is True
+        assert env_by_cmd["pidof"] is clean_env
+
+    def test_check_freshclam_running_passes_clean_env(self, updater_module):
+        """_check_freshclam_running's pidof probe gets the clean env."""
+        from src.core.updater import FreshclamUpdater
+
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+
+        with (
+            patch("src.core.updater.get_clean_env", return_value=clean_env),
+            patch("src.core.updater.wrap_host_command", side_effect=lambda x: x),
+            patch(
+                "subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="777"),
+            ) as mock_run,
+        ):
+            updater = FreshclamUpdater(log_manager=MagicMock())
+            is_running, pid = updater._check_freshclam_running()
+
+        assert is_running is True
+        assert pid == "777"
+        assert mock_run.call_args.kwargs["env"] is clean_env
+
+
+# =============================================================================
 # Additional UpdateResult Tests
 # =============================================================================
 

--- a/tests/e2e/test_scan_flow.py
+++ b/tests/e2e/test_scan_flow.py
@@ -609,9 +609,36 @@ class TestE2EScanResultParsing:
         E2E Test: Parse permission warnings and treat exit code 2 as clean when appropriate.
 
         Steps:
-        1. Feed stdout containing only failed-to-open warnings and no infections.
+        1. Feed stdout containing failed-to-open warnings, no infections, and
+           at least one successfully scanned file.
         2. Parse with exit code 2.
         3. Verify CLEAN status with skipped file warnings populated.
+        """
+        scanner = Scanner(log_manager=e2e_env["log_manager"], settings_manager=e2e_env["settings"])
+        warning_output = """/root/secret1: Failed to open file ERROR
+/root/secret2: Failed to open file ERROR
+
+----------- SCAN SUMMARY -----------
+Scanned directories: 1
+Scanned files: 1
+Infected files: 0
+"""
+
+        result = scanner._parse_results(str(e2e_env["scan_dir"]), warning_output, "", 2)
+
+        assert result.status == ScanStatus.CLEAN
+        assert result.skipped_count == 2
+        assert len(result.skipped_files or []) == 2
+        assert "could not be accessed" in (result.warning_message or "")
+
+    def test_e2e_parse_all_files_failed_is_error(self, e2e_env):
+        """
+        E2E Test: Exit code 2 with zero scanned files is an error, not a clean scan.
+
+        Steps:
+        1. Feed stdout where every file failed to open (Scanned files: 0).
+        2. Parse with exit code 2.
+        3. Verify ERROR status with a specific message instead of a green result.
         """
         scanner = Scanner(log_manager=e2e_env["log_manager"], settings_manager=e2e_env["settings"])
         warning_output = """/root/secret1: Failed to open file ERROR
@@ -625,10 +652,8 @@ Infected files: 0
 
         result = scanner._parse_results(str(e2e_env["scan_dir"]), warning_output, "", 2)
 
-        assert result.status == ScanStatus.CLEAN
-        assert result.skipped_count == 2
-        assert len(result.skipped_files or []) == 2
-        assert "could not be accessed" in (result.warning_message or "")
+        assert result.status == ScanStatus.ERROR
+        assert "No files could be scanned" in (result.error_message or "")
 
 
 class TestE2EScanLogging:

--- a/tests/e2e/test_scheduled_scan_flow.py
+++ b/tests/e2e/test_scheduled_scan_flow.py
@@ -131,7 +131,7 @@ class TestE2EScheduleConfiguration:
 
         # Mock the CLI path to avoid needing the actual executable
         with mock.patch.object(
-            scheduler, "_get_cli_command_path", return_value="/usr/bin/clamui-scheduled-scan"
+            scheduler, "_get_cli_command_path", return_value=["/usr/bin/clamui-scheduled-scan"]
         ):
             if scheduler.backend == SchedulerBackend.SYSTEMD:
                 # Test systemd timer creation

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -1272,6 +1272,12 @@ class TestClamUIAppVirusTotalScan:
 class TestClamUIAppInitialScanPaths:
     """Regression tests for forwarding CLI-provided scan targets to the UI."""
 
+    def _make_idle_scan_view(self):
+        """Create a scan view mock that reports no scan in progress."""
+        mock_scan_view = mock.MagicMock()
+        mock_scan_view.is_scanning = False
+        return mock_scan_view
+
     def test_multiple_clamav_paths_populate_all_targets(self, app):
         """All CLI paths must be forwarded to the scan view, not just the first.
 
@@ -1279,7 +1285,7 @@ class TestClamUIAppInitialScanPaths:
         so launching ClamUI from a file manager with N selected files only scanned
         the first one ("Scan Target (1)" despite "Received N path(s)").
         """
-        mock_scan_view = mock.MagicMock()
+        mock_scan_view = self._make_idle_scan_view()
         app._scan_view = mock_scan_view
         app._initial_scan_paths = ["/tmp/a.pdf", "/tmp/b.pdf"]
         app._initial_use_virustotal = False
@@ -1295,7 +1301,7 @@ class TestClamUIAppInitialScanPaths:
 
     def test_single_clamav_path_uses_multi_target_api(self, app):
         """A single CLI path still goes through the multi-target replace API."""
-        mock_scan_view = mock.MagicMock()
+        mock_scan_view = self._make_idle_scan_view()
         app._scan_view = mock_scan_view
         app._initial_scan_paths = ["/tmp/only.pdf"]
         app._initial_use_virustotal = False
@@ -1308,7 +1314,7 @@ class TestClamUIAppInitialScanPaths:
     def test_virustotal_path_uses_first_only(self, app):
         """VirusTotal scans a single file per request, so only the first path is
         forwarded to the setup dialog and the ClamAV auto-scan is not started."""
-        mock_scan_view = mock.MagicMock()
+        mock_scan_view = self._make_idle_scan_view()
         app._scan_view = mock_scan_view
         app._initial_scan_paths = ["/tmp/a.pdf", "/tmp/b.pdf"]
         app._initial_use_virustotal = True
@@ -1323,7 +1329,7 @@ class TestClamUIAppInitialScanPaths:
 
     def test_no_paths_is_noop(self, app):
         """With no pending paths nothing is forwarded to the scan view."""
-        mock_scan_view = mock.MagicMock()
+        mock_scan_view = self._make_idle_scan_view()
         app._scan_view = mock_scan_view
         app._initial_scan_paths = []
 
@@ -1332,3 +1338,95 @@ class TestClamUIAppInitialScanPaths:
         mock_scan_view._replace_selected_paths.assert_not_called()
         mock_scan_view._set_selected_path.assert_not_called()
         mock_scan_view._start_scan.assert_not_called()
+
+    def test_second_invocation_while_scanning_is_ignored_with_toast(self, app, mock_gtk_modules):
+        """A second CLI/file-manager invocation during an active scan must not
+        touch the selection (the worker thread iterates it) — the request is
+        dropped and the user is told via a toast.
+
+        Regression: _replace_selected_paths() cleared and repopulated the same
+        list object the scan worker was iterating, while the new request was
+        silently swallowed by the _is_scanning guard.
+        """
+        mock_scan_view = mock.MagicMock()
+        mock_scan_view.is_scanning = True
+        app._scan_view = mock_scan_view
+        app._initial_scan_paths = ["/tmp/second-invocation.pdf"]
+        app._initial_use_virustotal = False
+
+        app._process_initial_scan_paths()
+
+        # The running scan's selection must remain untouched.
+        mock_scan_view._replace_selected_paths.assert_not_called()
+        mock_scan_view._set_selected_path.assert_not_called()
+        mock_scan_view._start_scan.assert_not_called()
+        # The dropped request is consumed so it cannot fire later.
+        assert app._initial_scan_paths == []
+        assert app._initial_use_virustotal is False
+        # The user is informed via the window's toast mechanism.
+        app.props.active_window.add_toast.assert_called_once()
+        toast_message = mock_gtk_modules["Adw"].Toast.new.call_args[0][0]
+        assert "already running" in toast_message
+        assert "ignored" in toast_message
+
+    def test_pre_activation_paths_stay_pending(self, app):
+        """Paths received before the scan view exists must stay pending.
+
+        Regression: the paths were popped BEFORE the scan-view guard, so a
+        pre-activation call consumed and silently dropped them.
+        """
+        app._scan_view = None
+        app._initial_scan_paths = ["/tmp/early.pdf", "/tmp/early2.pdf"]
+        app._initial_use_virustotal = True
+
+        app._process_initial_scan_paths()
+
+        assert app._initial_scan_paths == ["/tmp/early.pdf", "/tmp/early2.pdf"]
+        assert app._initial_use_virustotal is True
+
+    def test_processing_switches_to_scan_view(self, app):
+        """Starting a CLI-requested scan surfaces the scan view so a second
+        invocation does not scan invisibly under another view."""
+        mock_scan_view = self._make_idle_scan_view()
+        app._scan_view = mock_scan_view
+        app._current_view = "logs"
+        app._initial_scan_paths = ["/tmp/a.pdf"]
+        app._initial_use_virustotal = False
+
+        app._process_initial_scan_paths()
+
+        win = app.props.active_window
+        win.set_content_view.assert_called_once_with(mock_scan_view)
+        win.set_active_view.assert_called_once_with("scan")
+        assert app._current_view == "scan"
+        mock_scan_view._start_scan.assert_called_once_with()
+
+    def test_virustotal_multi_select_shows_ignored_toast(self, app, mock_gtk_modules):
+        """Selecting several files for a VirusTotal scan (KDE desktop file uses
+        %F) must tell the user that only the first file is scanned."""
+        mock_scan_view = self._make_idle_scan_view()
+        app._scan_view = mock_scan_view
+        app._show_virustotal_setup_dialog = mock.MagicMock()
+        app._initial_scan_paths = ["/tmp/a.pdf", "/tmp/b.pdf", "/tmp/c.pdf"]
+        app._initial_use_virustotal = True
+
+        app._process_initial_scan_paths()
+
+        mock_scan_view._set_selected_path.assert_called_once_with("/tmp/a.pdf")
+        app._show_virustotal_setup_dialog.assert_called_once_with("/tmp/a.pdf")
+        app.props.active_window.add_toast.assert_called_once()
+        toast_message = mock_gtk_modules["Adw"].Toast.new.call_args[0][0]
+        assert "VirusTotal" in toast_message
+        assert "2" in toast_message
+
+    def test_virustotal_single_path_shows_no_toast(self, app):
+        """A single-file VirusTotal request needs no 'selections ignored' toast."""
+        mock_scan_view = self._make_idle_scan_view()
+        app._scan_view = mock_scan_view
+        app._show_virustotal_setup_dialog = mock.MagicMock()
+        app._initial_scan_paths = ["/tmp/a.pdf"]
+        app._initial_use_virustotal = True
+
+        app._process_initial_scan_paths()
+
+        app.props.active_window.add_toast.assert_not_called()

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -1400,6 +1400,9 @@ class TestClamUIAppInitialScanPaths:
         win.set_active_view.assert_called_once_with("scan")
         assert app._current_view == "scan"
         mock_scan_view._start_scan.assert_called_once_with()
+        # The reflective switch_to_view helper was removed; the coordinator
+        # is called directly instead.
+        assert not hasattr(app, "switch_to_view")
 
     def test_virustotal_multi_select_shows_ignored_toast(self, app, mock_gtk_modules):
         """Selecting several files for a VirusTotal scan (KDE desktop file uses

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -100,24 +100,21 @@ def parse_file_arguments(request):
     # Mock the matplotlib GTK backend
     mock_backend = mock.MagicMock()
 
-    # Store original modules
-    original_modules = {}
-    modules_to_mock = [
-        "gi",
-        "gi.repository",
-        "gi.repository.Adw",
-        "gi.repository.Gtk",
-        "gi.repository.Gio",
-        "gi.repository.GLib",
-        "gi.repository.Gdk",
-        "gi.repository.GObject",
-        "gi.repository.Pango",
-        "matplotlib.backends.backend_gtk4",
-        "matplotlib.backends.backend_gtk4agg",
-    ]
+    def _is_displaced_module(name: str) -> bool:
+        """Match every module this fixture clears or replaces with a mock."""
+        return (
+            name == "gi"
+            or name.startswith(("gi.", "src.", "matplotlib.backends.backend_gtk4"))
+        )
 
-    for mod in modules_to_mock:
-        original_modules[mod] = sys.modules.get(mod)
+    # Snapshot every module the fixture displaces so teardown can restore the
+    # exact objects other test modules captured at import/collection time.
+    # (Previously the cleared src.* modules were dropped for good, so e.g.
+    # tests/cli/test_scan_cmd.py patched a re-imported src.cli.scan_cmd while
+    # calling a stale `run` bound to the original module's globals.)
+    original_modules = {
+        name: module for name, module in sys.modules.items() if _is_displaced_module(name)
+    }
 
     # Set up mocks
     sys.modules["gi"] = mock_gi
@@ -145,12 +142,11 @@ def parse_file_arguments(request):
         def cleanup():
             global _cached_parse_file_arguments
             _cached_parse_file_arguments = None
-            for mod, original in original_modules.items():
-                if original is not None:
-                    sys.modules[mod] = original
-                elif mod in sys.modules:
-                    del sys.modules[mod]
-            _clear_src_modules()
+            # Drop the mocks plus everything imported under them, then put
+            # back the previously loaded module objects.
+            for name in [mod for mod in sys.modules if _is_displaced_module(mod)]:
+                del sys.modules[name]
+            sys.modules.update(original_modules)
 
         request.addfinalizer(cleanup)
 
@@ -343,42 +339,76 @@ class TestSymlinks:
         assert not os.path.exists(result[0])
 
 
+@pytest.fixture
+def clamui_app(parse_file_arguments):
+    """Create a real ClamUIApp instance under the module's GTK mocks."""
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "src.ui.window": mock.MagicMock(),
+            "src.ui.scan_view": mock.MagicMock(),
+            "src.ui.update_view": mock.MagicMock(),
+            "src.ui.logs_view": mock.MagicMock(),
+            "src.ui.components_view": mock.MagicMock(),
+            "src.ui.statistics_view": mock.MagicMock(),
+            "src.ui.preferences": mock.MagicMock(),
+            "src.ui.preferences.window": mock.MagicMock(),
+        },
+    ):
+        if "src.app" in sys.modules:
+            del sys.modules["src.app"]
+
+        from src.app import ClamUIApp
+
+        yield ClamUIApp()
+
+
 class TestPathValidationInApp:
-    """Tests for path validation in ClamUIApp.set_initial_scan_paths."""
+    """Tests for the real ClamUIApp.set_initial_scan_paths contract.
 
-    def test_set_initial_scan_paths_filters_nonexistent(self, tmp_path):
-        """Test that set_initial_scan_paths filters out non-existent paths.
+    set_initial_scan_paths performs NO existence filtering: every parsed
+    path is stored and forwarded as-is (validation happens later, during
+    the scan itself).
+    """
 
-        Note: This test verifies the filtering logic without importing the actual
-        ClamUIApp class, which requires GTK dependencies.
-        """
+    def test_set_initial_scan_paths_forwards_paths_unfiltered(self, clamui_app, tmp_path):
+        """Existing and non-existent paths are both forwarded to the scan view."""
         existing_file = tmp_path / "exists.txt"
         existing_file.write_text("content")
         nonexistent = "/nonexistent/path.txt"
-
-        # Replicate the path filtering logic from ClamUIApp.set_initial_scan_paths
         paths = [str(existing_file), nonexistent]
-        valid_paths = []
-        for path in paths:
-            if os.path.exists(path):
-                valid_paths.append(path)
 
-        # Verify filtering logic
-        assert len(valid_paths) == 1
-        assert str(existing_file) in valid_paths
-        assert nonexistent not in valid_paths
+        scan_view = mock.MagicMock()
+        scan_view.is_scanning = False
+        clamui_app._scan_view = scan_view
 
-    def test_set_initial_scan_paths_all_nonexistent(self):
-        """Test set_initial_scan_paths with all non-existent paths."""
+        clamui_app.set_initial_scan_paths(paths)
+
+        scan_view._replace_selected_paths.assert_called_once_with(paths)
+        scan_view._start_scan.assert_called_once_with()
+        # Consumed once forwarded.
+        assert clamui_app._initial_scan_paths == []
+
+    def test_set_initial_scan_paths_keeps_paths_pending_without_scan_view(self, clamui_app):
+        """Before the scan view exists the paths must stay pending, not be dropped."""
         paths = ["/nonexistent/path1.txt", "/nonexistent/path2.txt"]
-        valid_paths = [p for p in paths if os.path.exists(p)]
-        assert len(valid_paths) == 0
+        clamui_app._scan_view = None
 
-    def test_set_initial_scan_paths_empty_list(self):
-        """Test set_initial_scan_paths with empty list."""
-        paths = []
-        valid_paths = [p for p in paths if os.path.exists(p)]
-        assert valid_paths == []
+        clamui_app.set_initial_scan_paths(paths, use_virustotal=True)
+
+        assert clamui_app._initial_scan_paths == paths
+        assert clamui_app._initial_use_virustotal is True
+
+    def test_set_initial_scan_paths_empty_list_is_noop(self, clamui_app):
+        """An empty path list is stored but never forwarded."""
+        scan_view = mock.MagicMock()
+        scan_view.is_scanning = False
+        clamui_app._scan_view = scan_view
+
+        clamui_app.set_initial_scan_paths([])
+
+        scan_view._replace_selected_paths.assert_not_called()
+        scan_view._start_scan.assert_not_called()
 
 
 class TestQueueFilesForScan:

--- a/tests/ui/scan/test_scan_controller.py
+++ b/tests/ui/scan/test_scan_controller.py
@@ -539,7 +539,8 @@ class TestResultAggregation:
         _assert_status(agg, "infected")
 
     def test_aggregate_result_merges_skipped_and_warning_fields(self, controller):
-        """Skipped files dedup across targets; counts sum; messages stay distinct."""
+        """Skipped files dedup across targets; count matches the deduped list;
+        messages stay distinct."""
         from src.ui.scan.scan_controller import AggregatedResult
 
         agg = AggregatedResult()
@@ -567,7 +568,9 @@ class TestResultAggregation:
         controller._aggregate_result(agg, second)
 
         assert agg.skipped_files == ["/a/locked", "/shared/locked", "/b/locked"]
-        assert agg.skipped_count == 4
+        # The count must equal the deduplicated list, not the sum of the
+        # per-target counts (the shared file would otherwise count twice).
+        assert agg.skipped_count == len(agg.skipped_files) == 3
         assert agg.nonfatal_warnings == [
             "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN",
             "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits",
@@ -763,3 +766,64 @@ class TestWorkerExceptionRecovery:
         # Completion must fire exactly once so the UI leaves the scanning state.
         on_complete.assert_called_once()
         _assert_status(on_complete.call_args[0][0], "error")
+
+
+# =============================================================================
+# Finalization ordering (is_scanning race)
+# =============================================================================
+
+
+class TestScanFinalization:
+    """The worker must not flip state to IDLE before the main-loop finalizer.
+
+    Regression: the worker thread set _state = IDLE in its finally block
+    before the queued idle callbacks ran, opening a window where a re-entrant
+    start_scan() on the main thread could spawn a second worker while the
+    first scan's completion callbacks were still pending.
+    """
+
+    def test_state_stays_scanning_until_finalizer_runs(
+        self, mock_gi_for_controller, scanner, settings
+    ):
+        if "src.ui.scan.scan_controller" in sys.modules:
+            del sys.modules["src.ui.scan.scan_controller"]
+        from src.ui.scan.scan_controller import ScanController, ScanState
+
+        # Queue idle callbacks instead of executing them, emulating a busy
+        # main loop that has not dispatched them yet.
+        queued = []
+        mock_gi_for_controller.idle_add.side_effect = lambda fn, *a: queued.append((fn, a)) or 1
+
+        controller = ScanController(scanner, settings)
+        states = []
+        on_complete = MagicMock()
+        controller.set_callbacks(
+            on_state_change=lambda s: states.append(s),
+            on_complete=on_complete,
+        )
+
+        controller.start_scan(["/tmp/target"])
+
+        # Wait for the worker thread to finish and queue the finalizer.
+        deadline = time.monotonic() + 2.0
+        while not queued and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert queued, "worker never queued the finalizer idle callback"
+
+        # Worker is done, but the finalizer has not run: still SCANNING, no
+        # completion delivered, and a re-entrant start is ignored.
+        assert controller.state == ScanState.SCANNING
+        assert controller.is_scanning is True
+        on_complete.assert_not_called()
+        controller.start_scan(["/tmp/second"])
+        assert scanner.scan_sync.call_count == 1
+
+        # Dispatch the queued idles as the main loop would.
+        for fn, args in list(queued):
+            fn(*args)
+
+        assert controller.state == ScanState.IDLE
+        assert controller.is_scanning is False
+        assert states[-1] == ScanState.IDLE
+        on_complete.assert_called_once()
+        _assert_status(on_complete.call_args[0][0], "clean")

--- a/tests/ui/scan/test_scan_controller.py
+++ b/tests/ui/scan/test_scan_controller.py
@@ -42,6 +42,10 @@ def _make_result(
     infected_files=None,
     error_message=None,
     threat_details=None,
+    skipped_files=None,
+    skipped_count=0,
+    warning_message=None,
+    nonfatal_warnings=None,
 ):
     """Create a ScanResult using fresh imports to avoid enum identity issues."""
     from src.core.scanner_types import ScanResult, ScanStatus
@@ -59,6 +63,10 @@ def _make_result(
         infected_count=infected_count,
         error_message=error_message,
         threat_details=threat_details or [],
+        skipped_files=skipped_files or [],
+        skipped_count=skipped_count,
+        warning_message=warning_message,
+        nonfatal_warnings=nonfatal_warnings or [],
     )
 
 
@@ -419,6 +427,45 @@ class TestAggregatedResult:
         result = agg.to_scan_result(["/only/one"])
         assert result.path == "/only/one"
 
+    def test_to_scan_result_forwards_skipped_warning_fields(self, mock_gi_for_controller):
+        """Skipped files and nonfatal warnings must survive the conversion."""
+        if "src.ui.scan.scan_controller" in sys.modules:
+            del sys.modules["src.ui.scan.scan_controller"]
+        from src.ui.scan.scan_controller import AggregatedResult
+
+        agg = AggregatedResult(
+            skipped_files=["/a/locked", "/b/locked"],
+            skipped_count=2,
+            nonfatal_warnings=["LibClamAV Warning: cli_scanxz: exceeds limits"],
+        )
+        result = agg.to_scan_result(["/a", "/b"])
+        assert result.skipped_files == ["/a/locked", "/b/locked"]
+        assert result.skipped_count == 2
+        assert result.nonfatal_warnings == ["LibClamAV Warning: cli_scanxz: exceeds limits"]
+        assert result.warning_message == "2 file(s) could not be accessed"
+        assert result.has_warnings
+
+    def test_to_scan_result_warning_message_without_skips(self, mock_gi_for_controller):
+        """Without skipped files, distinct per-target messages are joined."""
+        if "src.ui.scan.scan_controller" in sys.modules:
+            del sys.modules["src.ui.scan.scan_controller"]
+        from src.ui.scan.scan_controller import AggregatedResult
+
+        agg = AggregatedResult(warning_messages=["limit warning A", "limit warning B"])
+        result = agg.to_scan_result(["/a"])
+        assert result.warning_message == "limit warning A; limit warning B"
+        assert result.skipped_count == 0
+
+    def test_to_scan_result_no_warnings_yields_none_message(self, mock_gi_for_controller):
+        if "src.ui.scan.scan_controller" in sys.modules:
+            del sys.modules["src.ui.scan.scan_controller"]
+        from src.ui.scan.scan_controller import AggregatedResult
+
+        agg = AggregatedResult()
+        result = agg.to_scan_result(["/a"])
+        assert result.warning_message is None
+        assert not result.has_warnings
+
 
 # =============================================================================
 # Result Aggregation Logic
@@ -490,6 +537,42 @@ class TestResultAggregation:
         assert agg.total_dirs == 5
         assert agg.total_infected == 1
         _assert_status(agg, "infected")
+
+    def test_aggregate_result_merges_skipped_and_warning_fields(self, controller):
+        """Skipped files dedup across targets; counts sum; messages stay distinct."""
+        from src.ui.scan.scan_controller import AggregatedResult
+
+        agg = AggregatedResult()
+        first = _make_result(
+            status_value="clean",
+            path="/a",
+            skipped_files=["/a/locked", "/shared/locked"],
+            skipped_count=2,
+            warning_message="2 file(s) could not be accessed",
+            nonfatal_warnings=["LibClamAV Warning: cli_tnef: file truncated, returning CLEAN"],
+        )
+        second = _make_result(
+            status_value="clean",
+            path="/b",
+            skipped_files=["/shared/locked", "/b/locked"],
+            skipped_count=2,
+            warning_message="2 file(s) could not be accessed",
+            nonfatal_warnings=[
+                "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN",
+                "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits",
+            ],
+        )
+
+        controller._aggregate_result(agg, first)
+        controller._aggregate_result(agg, second)
+
+        assert agg.skipped_files == ["/a/locked", "/shared/locked", "/b/locked"]
+        assert agg.skipped_count == 4
+        assert agg.nonfatal_warnings == [
+            "LibClamAV Warning: cli_tnef: file truncated, returning CLEAN",
+            "LibClamAV Warning: cli_scanxz: decompress file size exceeds limits",
+        ]
+        assert agg.warning_messages == ["2 file(s) could not be accessed"]
 
     def test_aggregate_partial_from_cancelled(self, controller):
         """_aggregate_partial should accumulate partial data without status change."""

--- a/tests/ui/test_audit_view.py
+++ b/tests/ui/test_audit_view.py
@@ -1134,6 +1134,23 @@ class TestEdgeCases:
         assert mock_popen.call_args[0][0] == ["gufw"]
         _clear_src_modules()
 
+    @patch("subprocess.Popen")
+    def test_on_launch_clicked_passes_clean_env(self, mock_popen, mock_gi_modules):
+        """Issue #155 residual: gufw/firewall-config are host Python/GTK
+        scripts. With stderr=DEVNULL a leaked AppImage PYTHONHOME kills them
+        instantly and silently, so Popen must get the sanitized environment."""
+        AuditView, *_ = _import_all(mock_gi_modules)
+        view = _create_view(AuditView)
+        clean_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+
+        with patch("src.core.flatpak.get_clean_env", return_value=clean_env) as mock_clean:
+            view._on_launch_clicked(MagicMock(), "gufw")
+
+        mock_clean.assert_called_once()
+        assert mock_popen.call_args[0][0] == ["gufw"]
+        assert mock_popen.call_args.kwargs["env"] is clean_env
+        _clear_src_modules()
+
     @patch("subprocess.Popen", side_effect=FileNotFoundError)
     def test_on_launch_clicked_handles_missing_binary(self, mock_popen, mock_gi_modules):
         AuditView, *_ = _import_all(mock_gi_modules)

--- a/tests/ui/test_scan_results_dialog.py
+++ b/tests/ui/test_scan_results_dialog.py
@@ -239,6 +239,61 @@ class TestStatsSection:
         parent.append.assert_called_once()
         _clear_src_modules()
 
+    def test_clean_scan_skipped_count_subtitle(self, mock_gi_modules):
+        """Skipped files render the not-accessible count in the subtitle."""
+        result = _make_scan_result(
+            status_name="CLEAN",
+            has_warnings=True,
+            skipped_count=5,
+            warning_message="5 file(s) could not be accessed",
+        )
+        dialog = self._setup(mock_gi_modules, result)
+        expander = MagicMock()
+        mock_gi_modules["adw"].ExpanderRow = MagicMock(return_value=expander)
+        parent = MagicMock()
+
+        dialog._create_stats_section(parent)
+
+        subtitle = expander.set_subtitle.call_args[0][0]
+        assert "5 file(s) not accessible" in subtitle
+        _clear_src_modules()
+
+    def test_clean_scan_nonfatal_warning_never_shows_zero_files(self, mock_gi_modules):
+        """Regression: with skipped_count == 0 but nonfatal warnings present,
+        the CLEAN subtitle said "0 file(s) not accessible" instead of the
+        actual warning message."""
+        result = _make_scan_result(
+            status_name="CLEAN",
+            has_warnings=True,
+            skipped_count=0,
+            warning_message="LibClamAV Warning: bytecode execution failed",
+        )
+        dialog = self._setup(mock_gi_modules, result)
+        expander = MagicMock()
+        mock_gi_modules["adw"].ExpanderRow = MagicMock(return_value=expander)
+        parent = MagicMock()
+
+        dialog._create_stats_section(parent)
+
+        subtitle = expander.set_subtitle.call_args[0][0]
+        assert "0 file(s)" not in subtitle
+        assert "No threats found" in subtitle
+        assert "LibClamAV Warning: bytecode execution failed" in subtitle
+        _clear_src_modules()
+
+    def test_clean_scan_no_warnings_plain_subtitle(self, mock_gi_modules):
+        result = _make_scan_result(status_name="CLEAN")
+        dialog = self._setup(mock_gi_modules, result)
+        expander = MagicMock()
+        mock_gi_modules["adw"].ExpanderRow = MagicMock(return_value=expander)
+        parent = MagicMock()
+
+        dialog._create_stats_section(parent)
+
+        subtitle = expander.set_subtitle.call_args[0][0]
+        assert subtitle == "No threats found"
+        _clear_src_modules()
+
 
 class TestStatRow:
     """Test _create_stat_row helper."""

--- a/tests/ui/test_scan_view.py
+++ b/tests/ui/test_scan_view.py
@@ -26,6 +26,23 @@ def _clear_src_modules():
         del sys.modules[mod]
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _restore_src_modules_after_module():
+    """Restore the src.* modules displaced by this module's GTK mocking.
+
+    The fixtures here (and conftest's mock_gi_modules) clear src.* modules
+    around every test. Without restoring the original module objects, test
+    modules that imported src symbols at collection time (e.g.
+    tests/cli/test_scan_cmd.py) would later patch a re-imported module while
+    calling stale references bound to the original module's globals.
+    """
+    snapshot = {name: module for name, module in sys.modules.items() if name.startswith("src.")}
+    yield
+    for name in [mod for mod in sys.modules if mod.startswith("src.")]:
+        del sys.modules[name]
+    sys.modules.update(snapshot)
+
+
 @pytest.fixture
 def scan_view_class(mock_gi_modules):
     """Get ScanView class with mocked dependencies."""
@@ -938,6 +955,10 @@ class TestScanWorker:
         mock_result.stdout = "Scanned 10 files"
         mock_result.stderr = ""
         mock_result.error_message = None
+        mock_result.skipped_files = []
+        mock_result.skipped_count = 0
+        mock_result.warning_message = None
+        mock_result.nonfatal_warnings = []
 
         mock_scan_view._scanner.scan_sync.return_value = mock_result
         mock_scan_view._selected_paths = ["/home/user/test.txt"]
@@ -986,6 +1007,10 @@ class TestScanWorker:
         mock_result.stdout = ""
         mock_result.stderr = ""
         mock_result.error_message = None
+        mock_result.skipped_files = []
+        mock_result.skipped_count = 0
+        mock_result.warning_message = None
+        mock_result.nonfatal_warnings = []
 
         mock_scan_view._scanner.scan_sync.return_value = mock_result
         mock_scan_view._selected_paths = ["/home/user/eicar.txt"]
@@ -1084,6 +1109,10 @@ class TestMultiTargetScanning:
         mock_result.stdout = ""
         mock_result.stderr = ""
         mock_result.error_message = None
+        mock_result.skipped_files = []
+        mock_result.skipped_count = 0
+        mock_result.warning_message = None
+        mock_result.nonfatal_warnings = []
 
         # Make status comparisons work (return False so status != CANCELLED)
         mock_result.status.__eq__ = mock.MagicMock(return_value=False)
@@ -1127,6 +1156,10 @@ class TestMultiTargetScanning:
             result.stdout = f"scanned {files}"
             result.stderr = ""
             result.error_message = None
+            result.skipped_files = []
+            result.skipped_count = 0
+            result.warning_message = None
+            result.nonfatal_warnings = []
             return result
 
         results = [create_result(10, 0), create_result(20, 1), create_result(5, 0)]
@@ -1156,6 +1189,150 @@ class TestMultiTargetScanning:
                 call_kwargs = mock_scan_result_class.call_args[1]
                 assert call_kwargs["scanned_files"] == 35  # 10 + 20 + 5
                 assert call_kwargs["infected_count"] == 1
+
+    def _create_clean_result(self, **overrides):
+        """Create a clean per-target result mock with warning-field defaults."""
+        result = mock.MagicMock()
+        result.status = mock.MagicMock()
+        result.scanned_files = 1
+        result.scanned_dirs = 0
+        result.infected_count = 0
+        result.infected_files = []
+        result.threat_details = []
+        result.stdout = ""
+        result.stderr = ""
+        result.error_message = None
+        result.skipped_files = []
+        result.skipped_count = 0
+        result.warning_message = None
+        result.nonfatal_warnings = []
+        for name, value in overrides.items():
+            setattr(result, name, value)
+        return result
+
+    def test_scan_worker_snapshots_targets_against_concurrent_replacement(self, mock_scan_view):
+        """Replacing _selected_paths mid-scan must not affect the running worker.
+
+        Regression: a second CLI/file-manager invocation reached
+        _replace_selected_paths(), clearing and repopulating the SAME list the
+        worker thread was iterating. The worker now snapshots the targets once
+        and uses that snapshot for the whole scan session.
+        """
+        self._setup_multi_scan_mocks(mock_scan_view)
+
+        def scan_and_mutate(path, **kwargs):
+            # Simulate the main thread clearing and repopulating the selection
+            # (what _replace_selected_paths does) while this target scans.
+            mock_scan_view._selected_paths.clear()
+            mock_scan_view._selected_paths.extend(["/intruder1", "/intruder2", "/intruder3"])
+            return self._create_clean_result(scanned_files=5)
+
+        mock_scan_view._scanner.scan_sync.side_effect = scan_and_mutate
+        mock_scan_view._selected_paths = ["/path1", "/path2"]
+        mock_scan_view._cancel_all_requested = False
+
+        with mock.patch("src.ui.scan_view.GLib") as mock_glib:
+            mock_glib.idle_add.side_effect = lambda callback, *args: True
+
+            with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
+                mock_scan_status.CLEAN = "clean"
+                mock_scan_status.INFECTED = "infected"
+                mock_scan_status.ERROR = "error"
+                mock_scan_status.CANCELLED = "cancelled"
+
+                with mock.patch("src.ui.scan_view.ScanResult") as mock_scan_result_class:
+                    mock_scan_view._scan_worker()
+
+        # Only the snapshotted targets are scanned — never the intruders.
+        calls = mock_scan_view._scanner.scan_sync.call_args_list
+        assert [call[0][0] for call in calls] == ["/path1", "/path2"]
+        # The aggregated result path is derived from the snapshot too.
+        call_kwargs = mock_scan_result_class.call_args[1]
+        assert call_kwargs["path"] == "/path1, /path2"
+        assert call_kwargs["scanned_files"] == 10
+
+    def test_multi_target_scan_aggregates_skipped_and_warning_fields(self, mock_scan_view):
+        """skipped_files/skipped_count/warning_message must survive aggregation.
+
+        Regression (#149): the aggregated ScanResult dropped these fields
+        entirely, so multi-target scans could never surface warnings in the GUI.
+        """
+        self._setup_multi_scan_mocks(mock_scan_view)
+
+        results = [
+            self._create_clean_result(
+                skipped_files=["/root/secret.txt", "/root/other.txt"],
+                skipped_count=2,
+                warning_message="2 file(s) could not be accessed",
+                nonfatal_warnings=["LibClamAV Warning: first"],
+            ),
+            self._create_clean_result(
+                skipped_files=["/root/other.txt", "/etc/shadow"],
+                skipped_count=2,
+                warning_message="2 file(s) could not be accessed",
+                nonfatal_warnings=["LibClamAV Warning: first", "LibClamAV Warning: second"],
+            ),
+        ]
+        mock_scan_view._scanner.scan_sync.side_effect = results
+        mock_scan_view._selected_paths = ["/path1", "/path2"]
+        mock_scan_view._cancel_all_requested = False
+
+        with mock.patch("src.ui.scan_view.GLib") as mock_glib:
+            mock_glib.idle_add.side_effect = lambda callback, *args: True
+
+            with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
+                mock_scan_status.CLEAN = "clean"
+                mock_scan_status.INFECTED = "infected"
+                mock_scan_status.ERROR = "error"
+                mock_scan_status.CANCELLED = "cancelled"
+
+                with mock.patch("src.ui.scan_view.ScanResult") as mock_scan_result_class:
+                    mock_scan_view._scan_worker()
+
+        call_kwargs = mock_scan_result_class.call_args[1]
+        # Union of skipped files, deduplicated, order preserved.
+        assert call_kwargs["skipped_files"] == [
+            "/root/secret.txt",
+            "/root/other.txt",
+            "/etc/shadow",
+        ]
+        # Sum of per-target skipped counts.
+        assert call_kwargs["skipped_count"] == 4
+        # Summary re-derived with the single-target phrasing.
+        assert call_kwargs["warning_message"] == "4 file(s) could not be accessed"
+        # nonfatal_warnings aggregated (deduplicated) onto the result instance.
+        assert mock_scan_result_class.return_value.nonfatal_warnings == [
+            "LibClamAV Warning: first",
+            "LibClamAV Warning: second",
+        ]
+
+    def test_multi_target_scan_joins_nonskip_warning_messages(self, mock_scan_view):
+        """Without skipped files, distinct per-target warning messages are joined."""
+        self._setup_multi_scan_mocks(mock_scan_view)
+
+        results = [
+            self._create_clean_result(warning_message="scan completed with warnings"),
+            self._create_clean_result(),
+        ]
+        mock_scan_view._scanner.scan_sync.side_effect = results
+        mock_scan_view._selected_paths = ["/path1", "/path2"]
+        mock_scan_view._cancel_all_requested = False
+
+        with mock.patch("src.ui.scan_view.GLib") as mock_glib:
+            mock_glib.idle_add.side_effect = lambda callback, *args: True
+
+            with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
+                mock_scan_status.CLEAN = "clean"
+                mock_scan_status.INFECTED = "infected"
+                mock_scan_status.ERROR = "error"
+                mock_scan_status.CANCELLED = "cancelled"
+
+                with mock.patch("src.ui.scan_view.ScanResult") as mock_scan_result_class:
+                    mock_scan_view._scan_worker()
+
+        call_kwargs = mock_scan_result_class.call_args[1]
+        assert call_kwargs["skipped_count"] == 0
+        assert call_kwargs["warning_message"] == "scan completed with warnings"
 
 
 class TestCancelScan:
@@ -1198,6 +1375,10 @@ class TestCancelScan:
         mock_result.stdout = ""
         mock_result.stderr = ""
         mock_result.error_message = None
+        mock_result.skipped_files = []
+        mock_result.skipped_count = 0
+        mock_result.warning_message = None
+        mock_result.nonfatal_warnings = []
 
         mock_scan_view._scanner.scan_sync.return_value = mock_result
         mock_scan_view._selected_paths = ["/path1", "/path2", "/path3"]
@@ -1237,6 +1418,10 @@ class TestCancelScan:
             result.stdout = ""
             result.stderr = ""
             result.error_message = None
+            result.skipped_files = []
+            result.skipped_count = 0
+            result.warning_message = None
+            result.nonfatal_warnings = []
             return result
 
         mock_scan_view._scanner.scan_sync.side_effect = create_result_and_cancel
@@ -1299,6 +1484,8 @@ class TestScanComplete:
         result.infected_count = 0
         result.error_message = None
         result.stderr = ""
+        result.skipped_count = 0
+        result.warning_message = None
 
         # Make status comparison work for CLEAN
         with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
@@ -1317,6 +1504,62 @@ class TestScanComplete:
         mock_scan_view._cancel_button.set_visible.assert_called_with(False)
         mock_scan_view._stop_progress_pulse.assert_called_once()
         mock_scan_view._show_view_results.assert_called_once_with(0)
+
+    def test_on_scan_complete_clean_with_skipped_files_shows_count(self, mock_scan_view):
+        """A clean result with skipped files renders the not-accessible count."""
+        self._setup_complete_mocks(mock_scan_view)
+
+        clean_status = mock.MagicMock()
+        result = mock.MagicMock()
+        result.status = clean_status
+        result.infected_count = 0
+        result.error_message = None
+        result.stderr = ""
+        result.skipped_count = 3
+        result.warning_message = "3 file(s) could not be accessed"
+
+        with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
+            mock_scan_status.CLEAN = clean_status
+            mock_scan_status.INFECTED = mock.MagicMock()
+            mock_scan_status.ERROR = mock.MagicMock()
+            mock_scan_status.CANCELLED = mock.MagicMock()
+
+            mock_scan_view._on_scan_complete(result)
+
+        banner_title = mock_scan_view._status_banner.set_title.call_args[0][0]
+        assert "No threats found" in banner_title
+        assert "3 file(s) not accessible" in banner_title
+
+    def test_on_scan_complete_clean_nonfatal_warning_uses_warning_message(self, mock_scan_view):
+        """Warnings without skipped files must never render a bare '0 file(s)'.
+
+        Regression (#149): with skipped_count == 0 but a non-fatal warning
+        present, the banner said "0 file(s) not accessible" instead of
+        surfacing the actual warning message.
+        """
+        self._setup_complete_mocks(mock_scan_view)
+
+        clean_status = mock.MagicMock()
+        result = mock.MagicMock()
+        result.status = clean_status
+        result.infected_count = 0
+        result.error_message = None
+        result.stderr = ""
+        result.skipped_count = 0
+        result.warning_message = "LibClamAV Warning: bytecode execution failed"
+
+        with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
+            mock_scan_status.CLEAN = clean_status
+            mock_scan_status.INFECTED = mock.MagicMock()
+            mock_scan_status.ERROR = mock.MagicMock()
+            mock_scan_status.CANCELLED = mock.MagicMock()
+
+            mock_scan_view._on_scan_complete(result)
+
+        banner_title = mock_scan_view._status_banner.set_title.call_args[0][0]
+        assert "No threats found" in banner_title
+        assert "0 file(s)" not in banner_title
+        assert "LibClamAV Warning: bytecode execution failed" in banner_title
 
     def test_on_scan_complete_infected_result(self, mock_scan_view):
         """Test scan complete handler with infected result."""
@@ -1392,6 +1635,8 @@ class TestScanComplete:
         result.infected_count = 0
         result.error_message = None
         result.stderr = ""
+        result.skipped_count = 0
+        result.warning_message = None
 
         with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
             mock_scan_status.CLEAN = clean_status
@@ -1418,6 +1663,8 @@ class TestScanComplete:
         result.infected_count = 0
         result.error_message = None
         result.stderr = ""
+        result.skipped_count = 0
+        result.warning_message = None
 
         with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
             mock_scan_status.CLEAN = clean_status
@@ -2794,6 +3041,8 @@ class TestScanCompleteEicarCleanupError:
         result.infected_count = 0
         result.error_message = None
         result.stderr = ""
+        result.skipped_count = 0
+        result.warning_message = None
 
         with mock.patch("src.ui.scan_view.ScanStatus") as mock_scan_status:
             mock_scan_status.CLEAN = clean_status
@@ -2906,3 +3155,126 @@ class TestScanViewSharedQuarantineManager:
             assert view._quarantine_manager is mock_qm_instance
         finally:
             sv_module.QuarantineManager = original_qm
+
+
+class TestIsScanningProperty:
+    """Tests for the public is_scanning property used by app.py."""
+
+    def test_is_scanning_false_when_idle(self, mock_scan_view):
+        """The property mirrors the private _is_scanning flag (idle)."""
+        mock_scan_view._is_scanning = False
+
+        assert mock_scan_view.is_scanning is False
+
+    def test_is_scanning_true_while_scanning(self, mock_scan_view):
+        """The property mirrors the private _is_scanning flag (scanning)."""
+        mock_scan_view._is_scanning = True
+
+        assert mock_scan_view.is_scanning is True
+
+
+# =============================================================================
+# Composition-root ScanView (src/ui/scan/scan_view.py) Tests
+# =============================================================================
+
+
+@pytest.fixture
+def composition_scan_view_class(mock_gi_modules):
+    """Get the composition-root scan.ScanView class with mocked dependencies."""
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "src.core.scanner": mock.MagicMock(),
+            "src.core.quarantine": mock.MagicMock(),
+            "src.core.settings_manager": mock.MagicMock(),
+            "src.core.utils": mock.MagicMock(),
+            "src.ui.compat": mock.MagicMock(),
+            "src.ui.scan_results_dialog": mock.MagicMock(),
+            "src.ui.view_helpers": mock.MagicMock(),
+            "src.ui.scan.profile_selector": mock.MagicMock(),
+            "src.ui.scan.scan_controller": mock.MagicMock(),
+            "src.ui.scan.scan_progress_widget": mock.MagicMock(),
+            "src.ui.scan.scan_results_widget": mock.MagicMock(),
+            "src.ui.scan.target_selector": mock.MagicMock(),
+        },
+    ):
+        for cached in ("src.ui.scan", "src.ui.scan.scan_view"):
+            if cached in sys.modules:
+                del sys.modules[cached]
+
+        from src.ui.scan.scan_view import ScanView as CompositionScanView
+
+        yield CompositionScanView
+
+    _clear_src_modules()
+
+
+@pytest.fixture
+def composition_scan_view(composition_scan_view_class):
+    """Create a composition-root ScanView instance without running __init__."""
+    view = object.__new__(composition_scan_view_class)
+    view._target_selector = mock.MagicMock()
+    view._controller = mock.MagicMock()
+    return view
+
+
+class TestCompositionRootScanView:
+    """Switchover-parity tests for the composition-root scan.ScanView."""
+
+    def test_replace_selected_paths_delegates_to_target_selector(self, composition_scan_view):
+        """_replace_selected_paths must exist and delegate to set_paths.
+
+        Regression: app.py calls scan_view._replace_selected_paths(paths) for
+        multi-target CLI scans, but the designated replacement view lacked the
+        method entirely (AttributeError on switchover).
+        """
+        composition_scan_view._replace_selected_paths(["/tmp/a.pdf", "/tmp/b.pdf"])
+
+        composition_scan_view._target_selector.set_paths.assert_called_once_with(
+            ["/tmp/a.pdf", "/tmp/b.pdf"]
+        )
+
+    def test_is_scanning_mirrors_controller_state(self, composition_scan_view):
+        """The public is_scanning property mirrors the controller state."""
+        composition_scan_view._controller.is_scanning = True
+        assert composition_scan_view.is_scanning is True
+
+        composition_scan_view._controller.is_scanning = False
+        assert composition_scan_view.is_scanning is False
+
+    def test_setup_controller_wires_log_manager_into_scanner(self, composition_scan_view_class):
+        """The Scanner must receive the shared log_manager like the live view.
+
+        Regression: the composition root built Scanner without log_manager
+        while src/ui/scan_view.py passes one, so scan logs would use a
+        redundant LogManager instance after switchover.
+        """
+        view = object.__new__(composition_scan_view_class)
+        view._log_manager = mock.MagicMock(name="shared_log_manager")
+        view._settings_manager = mock.MagicMock(name="settings_manager")
+
+        sv_module = sys.modules["src.ui.scan.scan_view"]
+        with (
+            mock.patch.object(sv_module, "Scanner") as mock_scanner_class,
+            mock.patch.object(sv_module, "ScanController") as mock_controller_class,
+        ):
+            view._setup_controller()
+
+        mock_scanner_class.assert_called_once_with(
+            log_manager=view._log_manager, settings_manager=view._settings_manager
+        )
+        mock_controller_class.assert_called_once_with(
+            mock_scanner_class.return_value, view._settings_manager
+        )
+
+    def test_init_accepts_log_manager_keyword(self, composition_scan_view_class):
+        """__init__ stores the log_manager for the controller wiring."""
+        log_manager = mock.MagicMock(name="log_manager")
+
+        view = composition_scan_view_class(
+            settings_manager=mock.MagicMock(),
+            quarantine_manager=mock.MagicMock(),
+            log_manager=log_manager,
+        )
+
+        assert view._log_manager is log_manager

--- a/tests/ui/test_scan_view.py
+++ b/tests/ui/test_scan_view.py
@@ -18,6 +18,8 @@ from unittest import mock
 
 import pytest
 
+from tests.conftest import preserve_displaced_modules
+
 
 def _clear_src_modules():
     """Clear all cached src.* modules to prevent test pollution."""
@@ -36,11 +38,8 @@ def _restore_src_modules_after_module():
     tests/cli/test_scan_cmd.py) would later patch a re-imported module while
     calling stale references bound to the original module's globals.
     """
-    snapshot = {name: module for name, module in sys.modules.items() if name.startswith("src.")}
-    yield
-    for name in [mod for mod in sys.modules if mod.startswith("src.")]:
-        del sys.modules[name]
-    sys.modules.update(snapshot)
+    with preserve_displaced_modules():
+        yield
 
 
 @pytest.fixture
@@ -1296,12 +1295,13 @@ class TestMultiTargetScanning:
             "/root/other.txt",
             "/etc/shadow",
         ]
-        # Sum of per-target skipped counts.
-        assert call_kwargs["skipped_count"] == 4
+        # Count derived from the deduplicated list — the file skipped by both
+        # overlapping targets must not be counted twice.
+        assert call_kwargs["skipped_count"] == 3
         # Summary re-derived with the single-target phrasing.
-        assert call_kwargs["warning_message"] == "4 file(s) could not be accessed"
-        # nonfatal_warnings aggregated (deduplicated) onto the result instance.
-        assert mock_scan_result_class.return_value.nonfatal_warnings == [
+        assert call_kwargs["warning_message"] == "3 file(s) could not be accessed"
+        # nonfatal_warnings aggregated (deduplicated) into the constructor.
+        assert call_kwargs["nonfatal_warnings"] == [
             "LibClamAV Warning: first",
             "LibClamAV Warning: second",
         ]


### PR DESCRIPTION
Extends the issue #155 fix: get_clean_env() now also strips the
AppRun-exported GTK/pixbuf vars (GTK_PATH, GTK_EXE_PREFIX,
GTK_DATA_PREFIX, GSETTINGS_SCHEMA_DIR, GDK_PIXBUF_MODULE_FILE,
GDK_PIXBUF_MODULEDIR) so spawned host GTK apps don't load bundled
modules, and the remaining call sites that probe or launch host tools
pass the sanitized env: the Security Audit firewall-GUI launch button
(gufw/firewall-config are host Python scripts that died silently under
the leaked PYTHONHOME), the freshclam systemctl/pidof probes, the KDE
kbuildsycoca cache refresh, and the native xdg-open launches.

Adds wiring tests so a dropped env= kwarg can no longer pass unnoticed.

Refs #155

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xu4mq1TitaeGp319mxecXm