### PR TITLE
Fix VirusTotal setup dialog crash: use on_key_saved callback instead of non-existent signal

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -982,9 +982,9 @@ class ClamUIApp(Adw.Application):
 
         win = self.props.active_window
         if win:
-            dialog = VirusTotalSetupDialog(win)
-            dialog.connect(
-                "scan-requested", lambda d, key: self._trigger_virustotal_scan(file_path, key)
+            dialog = VirusTotalSetupDialog(
+                win,
+                on_key_saved=lambda key: self._trigger_virustotal_scan(file_path, key),
             )
             dialog.present()
 


### PR DESCRIPTION
The `_show_virustotal_setup_dialog` method in `src/app.py` was connecting to a signal named `"scan-requested"` on the `VirusTotalSetupDialog` object, but that signal does not exist in the dialog class. This causes a `TypeError` crash when the `--virustotal` CLI flag is used.

The `VirusTotalSetupDialog` uses constructor callbacks (`on_key_saved`, `on_open_website`) instead of GTK signals — the same pattern already used correctly in `src/core/clamav_config.py` (lines 51–52).

**Fix:** Pass `on_key_saved` as a constructor parameter instead of calling `dialog.connect("scan-requested", ...)`.

Fixes #183.