### PR TITLE
fix(flatpak): keep Hatchling dependencies self-contained

### DIFF
--- a/flathub/python3-build-deps.json
+++ b/flathub/python3-build-deps.json
@@ -17,6 +17,16 @@
         },
         {
             "type": "file",
+            "url": "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl",
+            "sha256": "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "packaging",
+                "packagetype": "bdist_wheel"
+            }
+        },
+        {
+            "type": "file",
             "url": "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl",
             "sha256": "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189",
             "x-checker-data": {


### PR DESCRIPTION
## Summary
- restore packaging 26.3 to the generated Hatchling build dependency module
- keep the build module self-contained instead of relying on packaging arriving through runtime dependencies
- generated with `--ignore-installed=packaging` because the GNOME SDK otherwise causes flatpak-pip-generator to omit it

## Verification
- packaging 26.3 wheel and checker metadata are present in `python3-build-deps.json`
- `git diff --check`
- the preceding regenerated dependency set passed a local Flatpak build and the full local suite (5,303 passed, 20 skipped)